### PR TITLE
Automatically depend on generating buildfile when creating a target

### DIFF
--- a/src/forge/Target.hpp
+++ b/src/forge/Target.hpp
@@ -42,6 +42,7 @@ class Target
     std::vector<Target*> dependencies_; ///< The Targets that this Target depends on.
     std::vector<Target*> implicit_dependencies_; ///< The Targets that this Target implicitly depends on.
     std::vector<Target*> ordering_dependencies_; ///< The Targets that must build before this Target is built.
+    std::vector<Target*> secondary_dependencies_; ///< The Targets that this Target depends on that aren't directly used in building.
     std::vector<std::string> filenames_; ///< The filenames of this Target.
     bool visiting_; ///< Whether or not this Target is in the process of being visited.
     int visited_revision_; ///< The visited revision the last time this Target was visited.
@@ -111,14 +112,18 @@ class Target
         void clear_implicit_dependencies();
         void add_ordering_dependency( Target* target );
         void clear_ordering_dependencies();
+        void add_secondary_dependency( Target* target );
+        void clear_secondary_dependencies();
         void remove_dependency( Target* target );
         bool is_explicit_dependency( Target* target ) const;
         bool is_implicit_dependency( Target* target ) const;
         bool is_ordering_dependency( Target* target ) const;
+        bool is_secondary_dependency( Target* target ) const;
         bool is_dependency( Target* target ) const;
         Target* explicit_dependency( int n ) const;
         Target* implicit_dependency( int n ) const;
         Target* ordering_dependency( int n ) const;
+        Target* secondary_dependency( int n ) const;
         Target* binding_dependency( int n ) const;
         Target* any_dependency( int n ) const;
 

--- a/src/forge/forge_lua/LuaTarget.cpp
+++ b/src/forge/forge_lua/LuaTarget.cpp
@@ -67,6 +67,7 @@ void LuaTarget::create( lua_State* lua_state )
         { "remove_dependency", &LuaTarget::remove_dependency },
         { "add_implicit_dependency", &LuaTarget::add_implicit_dependency },
         { "clear_implicit_dependencies", &LuaTarget::clear_implicit_dependencies },
+        { "add_secondary_dependency", &LuaTarget::add_secondary_dependency },
         { "add_ordering_dependency", &LuaTarget::add_ordering_dependency },
         { nullptr, nullptr }
     };
@@ -82,6 +83,8 @@ void LuaTarget::create( lua_State* lua_state )
         { "dependencies", &LuaTarget::explicit_dependencies },
         { "implicit_dependency", &LuaTarget::implicit_dependency },
         { "implicit_dependencies", &LuaTarget::implicit_dependencies },
+        { "secondary_dependency", &LuaTarget::secondary_dependency },
+        { "secondary_dependencies", &LuaTarget::secondary_dependencies },
         { "ordering_dependency", &LuaTarget::ordering_dependency },
         { "ordering_dependencies", &LuaTarget::ordering_dependencies },
         { "any_dependency", &LuaTarget::any_dependency },
@@ -578,6 +581,20 @@ int LuaTarget::clear_implicit_dependencies( lua_State* lua_state )
     return 0;
 }
 
+int LuaTarget::add_secondary_dependency( lua_State* lua_state )
+{
+    const int TARGET = 1;
+    const int DEPENDENCY = 2;
+    Target* target = (Target*) luaxx_to( lua_state, TARGET, TARGET_TYPE );
+    luaL_argcheck( lua_state, target != nullptr, TARGET, "nil target" );
+    if ( target )
+    {
+        Target* dependency = (Target*) luaxx_to( lua_state, DEPENDENCY, TARGET_TYPE );
+        target->add_secondary_dependency( dependency );
+    }
+    return 0;
+}
+
 int LuaTarget::add_ordering_dependency( lua_State* lua_state )
 {
     const int TARGET = 1;
@@ -845,6 +862,92 @@ int LuaTarget::implicit_dependencies( lua_State* lua_state )
     lua_pushinteger( lua_state, finish );
     lua_pushlightuserdata( lua_state, lua_target );
     lua_pushcclosure( lua_state, &LuaTarget::implicit_dependencies_iterator, 2 );
+    luaxx_push( lua_state, target );
+    lua_pushinteger( lua_state, start - 1 );
+    return 3;
+}
+
+int LuaTarget::secondary_dependency( lua_State* lua_state )
+{
+    SWEET_ASSERT( lua_state );
+
+    const int TARGET = 1;
+    const int INDEX = 2;
+    Target* target = (Target*) luaxx_to( lua_state, TARGET, TARGET_TYPE );
+    luaL_argcheck( lua_state, target != nullptr, TARGET, "expected target table" );
+
+    int index = lua_isnumber( lua_state, INDEX ) ? static_cast<int>( lua_tointeger(lua_state, INDEX) ) : 1;
+    luaL_argcheck( lua_state, index >= 1, INDEX, "expected index >= 1" );
+    --index;
+
+    Target* dependency = target->secondary_dependency( index );
+    if ( dependency )
+    {
+        if ( !dependency->referenced_by_script() )
+        {
+            LuaTarget* lua_target = reinterpret_cast<LuaTarget*>( lua_touserdata(lua_state, lua_upvalueindex(1)) );
+            SWEET_ASSERT( lua_target );
+            lua_target->create_target( dependency );
+        }
+        luaxx_push( lua_state, dependency );
+    }
+    else
+    {
+        lua_pushnil( lua_state );
+    }
+    return 1;
+}
+
+int LuaTarget::secondary_dependencies_iterator( lua_State* lua_state )
+{
+    const int TARGET = 1;
+    const int INDEX = 2;
+    const int FINISH = lua_upvalueindex( 1 );
+    const int LUA_TARGET = lua_upvalueindex( 2 );
+
+    int finish = static_cast<int>( lua_tointeger(lua_state, FINISH) );
+    Target* target = (Target*) luaxx_to( lua_state, TARGET, TARGET_TYPE );
+    int index = static_cast<int>( lua_tointeger(lua_state, INDEX) ) + 1;
+
+    if ( target && index <= finish )
+    {
+        Target* dependency = target->secondary_dependency( index - 1 );
+        if ( dependency )
+        {
+            if ( !dependency->referenced_by_script() )
+            {
+                LuaTarget* lua_target = reinterpret_cast<LuaTarget*>( lua_touserdata(lua_state, LUA_TARGET) );
+                SWEET_ASSERT( lua_target );
+                lua_target->create_target( dependency );
+            }
+            lua_pushinteger( lua_state, index );
+            luaxx_push( lua_state, dependency );
+            return 2;
+        }
+    }
+    return 0;
+}
+
+int LuaTarget::secondary_dependencies( lua_State* lua_state )
+{
+    const int TARGET = 1;
+    const int START = 2;
+    const int FINISH = 3;
+
+    Target* target = (Target*) luaxx_to( lua_state, TARGET, TARGET_TYPE );
+    luaL_argcheck( lua_state, target != NULL, TARGET, "expected target table" );
+
+    int start = static_cast<int>( luaL_optinteger(lua_state, START, 1) );
+    luaL_argcheck( lua_state, start >= 1, START, "expected start >= 1" );
+
+    int finish = static_cast<int>( luaL_optinteger(lua_state, FINISH, INT_MAX) );
+    luaL_argcheck( lua_state, finish >= start, FINISH, "expected finish >= start" );
+
+    LuaTarget* lua_target = reinterpret_cast<LuaTarget*>( lua_touserdata(lua_state, lua_upvalueindex(1)) );
+    SWEET_ASSERT( lua_target );    
+    lua_pushinteger( lua_state, finish );
+    lua_pushlightuserdata( lua_state, lua_target );
+    lua_pushcclosure( lua_state, &LuaTarget::secondary_dependencies_iterator, 2 );
     luaxx_push( lua_state, target );
     lua_pushinteger( lua_state, start - 1 );
     return 3;

--- a/src/forge/forge_lua/LuaTarget.hpp
+++ b/src/forge/forge_lua/LuaTarget.hpp
@@ -56,6 +56,7 @@ public:
     static int remove_dependency( lua_State* lua_state );
     static int add_implicit_dependency( lua_State* lua_state );
     static int clear_implicit_dependencies( lua_State* lua_state );
+    static int add_secondary_dependency( lua_State* lua_state );
     static int add_ordering_dependency( lua_State* lua_state );
     static int any_dependency( lua_State* lua_state );
     static int any_dependencies_iterator( lua_State* lua_state );
@@ -66,6 +67,9 @@ public:
     static int implicit_dependency( lua_State* lua_state );
     static int implicit_dependencies_iterator( lua_State* lua_state );
     static int implicit_dependencies( lua_State* lua_state );
+    static int secondary_dependency( lua_State* lua_state );
+    static int secondary_dependencies_iterator( lua_State* lua_state );
+    static int secondary_dependencies( lua_State* lua_state );
     static int ordering_dependency( lua_State* lua_state );
     static int ordering_dependencies_iterator( lua_State* lua_state );
     static int ordering_dependencies( lua_State* lua_state );

--- a/src/forge/lua/forge/init.lua
+++ b/src/forge/lua/forge/init.lua
@@ -193,6 +193,7 @@ function forge:FilePrototype( identifier, filename_modifier )
         target:set_filename( filename or target:path() );
         target:set_cleanable( true );
         target:add_ordering_dependency( forge:Directory(forge:branch(target)) );
+        target:add_secondary_dependency( self:current_buildfile() );
         return target;
     end;
     return file_prototype;
@@ -206,6 +207,7 @@ function forge:JavaStylePrototype( identifier, pattern )
         local output_directory = forge:root_relative():gsub( pattern, interpolate(forge, output_directory) );
         local target = forge:Target( forge:anonymous(), target_prototype );
         target:add_ordering_dependency( forge:Directory(output_directory) );
+        target:add_secondary_dependency( self:current_buildfile() );
         target:set_cleanable( true );
         return target;
     end
@@ -217,6 +219,7 @@ function forge:File( identifier, target_prototype )
     target:set_filename( target:path() );
     target:set_cleanable( true );
     target:add_ordering_dependency( self:Directory(self:branch(target)) );
+    target:add_secondary_dependency( self:current_buildfile() );
     return target;
 end
 


### PR DESCRIPTION
Adds secondary dependencies, identical to explicit dependencies but not returned when getting or iterating over explicit dependencies.  This allows for dependencies that affect the outdated calculation of the target without being directly used by any external tool that builds the target (e.g. passed on the command line).

Then each target that is created using the standard target creation functions in *forge/init.lua* adds the currently executing buildfile as a secondary dependency of the target that it is creating.

This rebuilds all targets specified in a buildfile when that buildfile changes.

The real dependencies are actually the command line arguments that are passed to the external tools but they're harder to track right now.

Modules should also add themselves as secondary dependencies as well as should the root *forge.lua* file but that is also a bit harder to do right now.

Thanks,
Charles