### PR TITLE
The installation instructions may be easily copied from `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,45 @@ Execute the build by running `forge` from a directory within the project:
 $ forge
 ~~~
 
+## Installation
+
+### Linux
+```
+git clone git@github.com:cwbaker/forge.git forge
+cd forge
+git submodule update --init
+bash ./bootstrap-linux.bash
+./bootstrap/bin/forge variant=shipping install
+```
+
+### Windows
+```
+git clone git@github.com:cwbaker/forge.git forge
+cd forge
+git submodule update --init
+bootstrap-windows.bat
+.\bootstrap\bin\forge.exe variant=shipping install
+```
+
+### macOS
+```
+git clone git@github.com:cwbaker/forge.git forge
+cd forge
+git submodule update --init
+bash ./bootstrap-macos.bash
+./bootstrap/bin/forge variant=shipping install
+```
+
+On all platforms, the binaries and associated [https://www.lua.org/](Lua) scripts will be installed in your [https://en.wikipedia.org/wiki/Home_directory](Home) directory, and should be added to your platform's `PATH` variable.
+
+A build may then be made within any directory containing a Forge project as below:
+
+```
+> forge
+```
+
+See [https://cwbaker.github.io/forge/installation/](Installation) for more complete documentation. Boa sorte!
+
 ## Documentation
 
 See [https://cwbaker.github.io/forge/](https://cwbaker.github.io/forge/) for more documentation.


### PR DESCRIPTION
I often have a little "bootstrap" script for building thirdparty dependencies (because everybody has a different build system 👯‍♂️ ) and being able to copy and paste it directly from the readme is just the thing a lazy slob like me needs ;)