### PR TITLE
Add transitive static library dependencies

### DIFF
--- a/src/forge/lua/forge/Target.lua
+++ b/src/forge/lua/forge/Target.lua
@@ -4,7 +4,7 @@ local Target = _G.Target;
 function Target.depend( toolset, target, dependencies )
     assert( type(dependencies) == 'table', 'Target.depend() parameter not a table as expected' );
     forge:merge( target, dependencies );
-    for _, value in forge:walk_tables(dependencies) do 
+    for _, value in walk_tables(dependencies) do 
         local source_file = toolset:SourceFile( value );
         target:add_dependency( source_file );
     end

--- a/src/forge/lua/forge/Toolset.lua
+++ b/src/forge/lua/forge/Toolset.lua
@@ -228,7 +228,7 @@ end
 function Toolset:all( dependencies )
     local all = Target( self, 'all' );
     if dependencies then 
-        for _, dependency in forge:walk_tables(dependencies) do
+        for _, dependency in walk_tables(dependencies) do
             if type(dependency) == 'string' then 
                 dependency = Target( self, self:interpolate(dependency) );
             end

--- a/src/forge/lua/forge/cc/DynamicLibrary.lua
+++ b/src/forge/lua/forge/cc/DynamicLibrary.lua
@@ -1,0 +1,20 @@
+
+local DynamicLibrary = TargetPrototype( 'DynamicLibrary' );
+
+function DynamicLibrary.create( toolset, identifier )
+    local identifier, filename = toolset:dynamic_library_filename( identifier );
+    local target = toolset:Target( identifier, DynamicLibrary );
+    target:set_filename( filename or target:path() );
+    target:set_cleanable( true );
+    target:add_ordering_dependency( toolset:Directory(branch(target)) );
+    return target;
+end
+
+function DynamicLibrary.build( toolset, target )
+    toolset:link( target );
+end
+
+-- See Executable.find_transitive_libraries().
+DynamicLibrary.find_transitive_libraries = require('forge.cc.Executable').find_transitive_libraries;
+
+return DynamicLibrary;

--- a/src/forge/lua/forge/cc/Executable.lua
+++ b/src/forge/lua/forge/cc/Executable.lua
@@ -1,0 +1,55 @@
+
+local Executable = TargetPrototype( 'Executable' );
+
+function Executable.create( toolset, identifier )
+    local identifier, filename = toolset:executable_filename( identifier );
+    local target = toolset:Target( identifier, Executable );
+    target:set_filename( filename or target:path() );
+    target:set_cleanable( true );
+    target:add_ordering_dependency( toolset:Directory(branch(target)) );
+    return target;
+end
+
+function Executable.build( toolset, target )
+    toolset:link( target );
+end
+
+-- Collect transitive dependencies on static and dynamic libraries.
+--
+-- Walks immediate dependencies adding static and dynamic libraries to a list
+-- of libraries.  Recursively walks the ordering dependencies of any static
+-- libraries to collect transitive static library dependencies.  Removes
+-- duplicate libraries preserving the most recently added duplicates at the
+-- end of the list.
+--
+-- Returns the list of static libraries to link with this executable.
+function Executable.find_transitive_libraries( target )
+    local toolset = target.toolset;
+    local function is_static_library( target ) 
+        return target:prototype() == toolset.StaticLibrary; 
+    end
+
+    local all_libraries = {};
+    local index_by_library = {};
+    for _, dependency in walk_dependencies(target) do
+        local prototype = dependency:prototype();
+        if prototype == toolset.StaticLibrary or prototype == toolset.DynamicLibrary then
+            table.insert( all_libraries, dependency );
+            index_by_library[dependency] = #all_libraries;
+            for _, dependency in walk_ordering_dependencies(dependency, is_static_library, is_static_library) do
+                table.insert( all_libraries, dependency );
+                index_by_library[dependency] = #all_libraries;
+            end
+        end
+    end
+
+    local libraries = {};
+    for index, library in ipairs(all_libraries) do
+        if index == index_by_library[library] then
+            table.insert( libraries, library );
+        end
+    end
+    return libraries;
+end
+
+return Executable;

--- a/src/forge/lua/forge/cc/StaticLibrary.lua
+++ b/src/forge/lua/forge/cc/StaticLibrary.lua
@@ -1,0 +1,38 @@
+
+local StaticLibrary = TargetPrototype( 'StaticLibrary' );
+
+function StaticLibrary.create( toolset, identifier )
+    local identifier, filename = toolset:static_library_filename( identifier );
+    local target = toolset:Target( identifier, StaticLibrary );
+    target:set_filename( filename or target:path() );
+    target:set_cleanable( true );
+    target:add_ordering_dependency( toolset:Directory(branch(target)) );
+    return target;
+end
+
+-- Add dependencies including transitive static library dependencies.
+--
+-- Assumes that strings or static libraries added as dependencies are intended
+-- to be transitive dependencies linked into the final executable or dynamic
+-- library.  Transitive dependencies are added as ordering dependencies so
+-- that they are built before they are linked but without causing the static
+-- library they're a direct dependency of to be rebuilt.
+function StaticLibrary.depend( toolset, target, dependencies )
+    assert( type(dependencies) == 'table', 'StaticLibrary.depend() parameter not a table as expected' );
+    forge:merge( target, dependencies );
+    for _, value in walk_tables(dependencies) do
+        if type(value) ~= 'table' or value:prototype() == toolset.StaticLibrary then
+            local library = toolset:SourceFile( value );
+            target:add_ordering_dependency( library );
+        else
+            local source_file = toolset:SourceFile( value );
+            target:add_dependency( source_file );
+        end
+    end
+end
+
+function StaticLibrary.build( toolset, target )
+    toolset:archive( target );
+end
+
+return StaticLibrary;


### PR DESCRIPTION
You can now add static libraries as dependencies of other static libraries and it will work, I believe, as you expect.  Archiving will ignore static library dependencies but linking will link all static libraries found as transitive dependencies.

The order of libraries should be correct in that dependent libraries are added later in the list.  However duplicates are not removed but that shouldn't be a practical problem.  There's also no checking for cycles in the transitive dependency walk so if your build is not running that is probably why!

Only tested on GCC and Pop!_OS so far.  But only Lua scripts were changed so I believe macOS and Windows, Clang and MSVC should also be okay.  Good luck and let me know how it goes.

You'll need to checkout and install from this PR (or at least use the build scripts from this PR; the executable itself didn't change).

Thanks,
Charles