### PR TITLE
Fix Windows hooking and group dependencies

### DIFF
--- a/src/forge/forge_hooks/forge_hooks_windows.cpp
+++ b/src/forge/forge_hooks/forge_hooks_windows.cpp
@@ -230,7 +230,10 @@ static HANDLE WINAPI create_file_a_hook( LPCSTR filename, DWORD desired_access, 
         flags,
         template_file
     );
-    log_file_access( filename, desired_access & GENERIC_WRITE );
+    if ( handle != INVALID_HANDLE_VALUE )
+    {
+        log_file_access( filename, desired_access & GENERIC_WRITE );
+    }
     return handle;
 }
 
@@ -245,10 +248,13 @@ static HANDLE WINAPI create_file_w_hook( LPCWSTR wide_filename, DWORD desired_ac
         flags,
         template_file
     );
-    char filename [MAX_PATH + 1];
-    int count = WideCharToMultiByte( CP_UTF8, 0, wide_filename, (int) wcslen(wide_filename), filename, (int) sizeof(filename), NULL, NULL );
-    filename[count] = 0;
-    log_file_access( filename, desired_access & GENERIC_WRITE );
+    if ( handle != INVALID_HANDLE_VALUE )
+    {
+        char filename [MAX_PATH + 1];
+        int count = WideCharToMultiByte( CP_UTF8, 0, wide_filename, (int) wcslen(wide_filename), filename, (int) sizeof(filename), NULL, NULL );
+        filename[count] = 0;
+        log_file_access( filename, desired_access & GENERIC_WRITE );
+    }
     return handle;
 }
 
@@ -266,7 +272,10 @@ static HANDLE WINAPI create_file_transacted_a_hook( LPCSTR filename, DWORD desir
         mini_version,
         extended_parameter
     );
-    log_file_access( filename, desired_access & GENERIC_WRITE );
+    if ( handle != INVALID_HANDLE_VALUE )
+    {
+        log_file_access( filename, desired_access & GENERIC_WRITE );
+    }
     return handle;
 }
 
@@ -284,10 +293,13 @@ static HANDLE WINAPI create_file_transacted_w_hook( LPCWSTR wide_filename, DWORD
         mini_version,
         extended_parameter
     );
-    char filename [MAX_PATH + 1];
-    int count = WideCharToMultiByte( CP_UTF8, 0, wide_filename, (int) wcslen(wide_filename), filename, (int) sizeof(filename), NULL, NULL );
-    filename[count] = 0;
-    log_file_access( filename, desired_access & GENERIC_WRITE );
+    if ( handle != INVALID_HANDLE_VALUE )
+    {
+        char filename [MAX_PATH + 1];
+        int count = WideCharToMultiByte( CP_UTF8, 0, wide_filename, (int) wcslen(wide_filename), filename, (int) sizeof(filename), NULL, NULL );
+        filename[count] = 0;
+        log_file_access( filename, desired_access & GENERIC_WRITE );
+    }
     return handle;
 }
 

--- a/src/forge/forge_test/transitive_dependencies.lua
+++ b/src/forge/forge_test/transitive_dependencies.lua
@@ -45,48 +45,50 @@ end
 
 remove( absolute('.forge') );
 
-require 'forge';
-local cc = require 'forge.cc.gcc' {};
+if operating_system() ~= 'windows' then
+    require 'forge';
+    local cc = require 'forge.cc.gcc' {};
 
-create( absolute('baz.o'), 1 );
-create( cc:static_library_filename('baz'), 1 );
-create( absolute('bar.c'), 1 );
-create( absolute('bar.o'), 1 );
-create( cc:static_library_filename('bar'), 1 );
-create( absolute('foo.o'), 1 );
-create( cc:static_library_filename('foo'), 1 );
-create( absolute('exe.o'), 1 );
-create( cc:executable_filename('exe'), 1 );
+    create( absolute('baz.o'), 1 );
+    create( cc:static_library_filename('baz'), 1 );
+    create( absolute('bar.c'), 1 );
+    create( absolute('bar.o'), 1 );
+    create( cc:static_library_filename('bar'), 1 );
+    create( absolute('foo.o'), 1 );
+    create( cc:static_library_filename('foo'), 1 );
+    create( absolute('exe.o'), 1 );
+    create( cc:executable_filename('exe'), 1 );
 
-local exe = dependency_graph( cc );
-local libraries = exe:find_transitive_libraries();
-CHECK( libraries[1] == find_target('foo') );
-CHECK( libraries[2] == find_target('bar') );
-CHECK( libraries[3] == find_target('baz') );
-CHECK( find_initial_target(exe) == exe );
-CHECK( #executions == 5 );
-CHECK( executions[1]:find('ar') );
-CHECK( executions[2]:find('gcc') );
-CHECK( executions[3]:find('ar') );
-CHECK( executions[4]:find('ar') );
-CHECK( executions[5]:find('g++') );
+    local exe = dependency_graph( cc );
+    local libraries = exe:find_transitive_libraries();
+    CHECK( libraries[1] == find_target('foo') );
+    CHECK( libraries[2] == find_target('bar') );
+    CHECK( libraries[3] == find_target('baz') );
+    CHECK( find_initial_target(exe) == exe );
+    CHECK( #executions == 5 );
+    CHECK( executions[1]:find('ar') );
+    CHECK( executions[2]:find('gcc') );
+    CHECK( executions[3]:find('ar') );
+    CHECK( executions[4]:find('ar') );
+    CHECK( executions[5]:find('g++') );
 
-touch( absolute('bar.c'), 2 );
+    touch( absolute('bar.c'), 2 );
 
-local exe = dependency_graph( cc );
-CHECK( #executions == 3 );
-CHECK( executions[1]:find('gcc') );
-CHECK( executions[2]:find('ar') );
-CHECK( executions[3]:find('g++') );
+    local exe = dependency_graph( cc );
+    CHECK( #executions == 3 );
+    CHECK( executions[1]:find('gcc') );
+    CHECK( executions[2]:find('ar') );
+    CHECK( executions[3]:find('g++') );
 
-touch( absolute('bar.o'), 2 );
-touch( cc:static_library_filename('bar'), 2 );
-touch( cc:static_library_filename('foo'), 2 );
-touch( cc:executable_filename('exe'), 2 );
+    touch( absolute('bar.o'), 2 );
+    touch( cc:static_library_filename('bar'), 2 );
+    touch( cc:static_library_filename('foo'), 2 );
+    touch( cc:executable_filename('exe'), 2 );
 
-local exe = dependency_graph( cc );
-print_dependencies( exe );
-print_executions();
-CHECK( #executions == 0 );
+    local exe = dependency_graph( cc );
+    print_dependencies( exe );
+    print_executions();
+    CHECK( #executions == 0 );
 
-remove( absolute('.forge') );
+    remove( absolute('.forge') );
+end

--- a/src/process/Process.cpp
+++ b/src/process/Process.cpp
@@ -42,6 +42,7 @@ Process::Process()
   environment_( NULL ),
   start_suspended_( false ),
   inherit_environment_( false ),
+  pipes_(),
 #if defined(BUILD_OS_WINDOWS)
   process_( INVALID_HANDLE_VALUE ),
   suspended_thread_( INVALID_HANDLE_VALUE )

--- a/src/process/Process.cpp
+++ b/src/process/Process.cpp
@@ -64,6 +64,12 @@ Process::~Process()
     resume();
 
 #if defined(BUILD_OS_WINDOWS)   
+    if ( suspended_thread_ != INVALID_HANDLE_VALUE )
+    {
+        ::CloseHandle( suspended_thread_ );
+        suspended_thread_ = INVALID_HANDLE_VALUE;
+    }
+
     if ( process_ != INVALID_HANDLE_VALUE )
     {
         ::CloseHandle( process_ );
@@ -464,6 +470,7 @@ void Process::resume()
     if ( suspended_thread_ != INVALID_HANDLE_VALUE )
     {
         ::ResumeThread( suspended_thread_ );
+        ::CloseHandle( suspended_thread_ );
         suspended_thread_ = INVALID_HANDLE_VALUE;
     }
 #elif defined(BUILD_OS_MACOS)


### PR DESCRIPTION
Fixes Visual C++ compilation using groups that was broken when dependency binding changed to calculate outdated only based on relative timestamps.  The corrected dependency binding now calculates outdated based on relative timestamps unless the target being bound is a phony target that doesn't bind to files.  Phony targets are outdated if any of their dependencies are outdated.

Also fixes hooking spawned processes that were failing because the THREAD_SET_CONTEXT permission wasn't granted on the spawned threads.  I think this might be some security feature of Windows that has recently been updated or changed.
