### PR TITLE
Compile for ARM processors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "src/lua"]
 	path = src/lua
 	url = https://github.com/cwbaker/lua.git
-[submodule "src/meow_hash"]
-	path = src/meow_hash
-	url = https://github.com/cwbaker/meow_hash.git

--- a/forge.lua
+++ b/forge.lua
@@ -25,7 +25,7 @@ local cc = require 'forge.cc' {
         ('BUILD_VARIANT_%s'):format( upper(variant) );
     };
 
-    architecture = 'x86_64';
+    architecture = 'native';
     assertions = variant ~= 'shipping';
     debug = variant ~= 'shipping';
     debuggable = variant ~= 'shipping';
@@ -46,9 +46,10 @@ local cc = require 'forge.cc' {
     warnings_as_errors = true;
 };
 
+local settings = cc.settings;
+
 -- Bump the C++ standard to c++14 when building on Windows as that is the 
 -- closest standard supported by Microsoft Visual C++.
-local settings = cc.settings;
 if settings.platform == 'windows' then
     settings.standard = 'c++14';
 end

--- a/src/forge/forge_lua/LuaSystem.hpp
+++ b/src/forge/forge_lua/LuaSystem.hpp
@@ -2,6 +2,7 @@
 #define FORGE_LUASYSTEM_HPP_INCLUDED
 
 #include <lua.hpp>
+#include <stdint.h>
 
 namespace sweet
 {
@@ -30,6 +31,8 @@ private:
     static int ticks( lua_State* lua_state );
     static int operating_system( lua_State* lua_state );
     static lua_Integer hash_recursively( lua_State* lua_state, int table, bool hash_integer_keys );
+    static uint64_t fnv1a_start();
+    static uint64_t fnv1a_append( uint64_t hash, const unsigned char* data, size_t length );
 };
 
 }

--- a/src/forge/lua/forge/cc/clang.lua
+++ b/src/forge/lua/forge/cc/clang.lua
@@ -71,6 +71,7 @@ function clang.initialize( toolset )
         standard = 'c++17';
         standard_library = 'libc++';
         strip = false;
+        toolchain = 'clang';
         verbose_linking = false;
         warning_level = 3;
         warnings_as_errors = true;

--- a/src/forge/lua/forge/cc/clang.lua
+++ b/src/forge/lua/forge/cc/clang.lua
@@ -58,7 +58,7 @@ function clang.initialize( toolset )
     toolset.Executable = Executable;
 
     toolset:defaults {
-        architecture = 'x86_64';
+        architecture = 'native';
         assertions = true;
         debug = true;
         exceptions = true;
@@ -234,8 +234,12 @@ function clang.append_compile_flags( toolset, target, flags, language )
     local settings = toolset.settings;
 
     table.insert( flags, '-c' );
-    table.insert( flags, ('-arch %s'):format(settings.architecture) );
     table.insert( flags, '-fasm-blocks' );
+
+    local architecture = settings.architecture;
+    if architecture ~= 'native' then
+        table.insert( flags, ('-arch %s'):format(architecture) );
+    end
 
     clang.append_flags( flags, target.cppflags );
     clang.append_flags( flags, settings.cppflags );
@@ -332,7 +336,10 @@ function clang.append_link_flags( toolset, target, flags )
     clang.append_flags( flags, settings.ldflags );
     clang.append_flags( flags, target.ldflags );
 
-    table.insert( flags, ('-arch %s'):format(settings.architecture) );
+    local architecture = settings.architecture;
+    if architecture ~= 'native' then
+        table.insert( flags, ('-arch %s'):format(architecture) );
+    end
 
     local standard = settings.standard;
     if standard then 

--- a/src/forge/lua/forge/cc/clang.lua
+++ b/src/forge/lua/forge/cc/clang.lua
@@ -236,12 +236,6 @@ function clang.append_compile_flags( toolset, target, flags, language )
     table.insert( flags, ('-arch %s'):format(settings.architecture) );
     table.insert( flags, '-fasm-blocks' );
 
-    -- Set "-maes" when compiling for x86_64 only to use Meow hash when 
-    -- building Forge itself.  This should be passed through settings.
-    if settings.architecture == 'x86_64' then
-        table.insert( flags, '-maes' );
-    end
-
     clang.append_flags( flags, target.cppflags );
     clang.append_flags( flags, settings.cppflags );
     

--- a/src/forge/lua/forge/cc/gcc.lua
+++ b/src/forge/lua/forge/cc/gcc.lua
@@ -48,7 +48,7 @@ function gcc.initialize( toolset )
     toolset.Executable = Executable;
 
     toolset:defaults {
-        architecture = 'x86_64';
+        architecture = 'native';
         assertions = true;
         debug = true;
         exceptions = true;
@@ -89,13 +89,6 @@ function gcc.executable_filename( toolset, identifier )
     local filename = identifier;
     return identifier, filename;
 end
-
-local flags_by_architecture = {
-    armv5 = '-march=armv5te -mtune=xscale -mthumb';
-    armv7 = '-march=armv7 -mtune=xscale -mthumb';
-    armv8 = '-march=armv8-a -mtune=xscale -mthumb';
-    x86_64 = '-march=westmere -maes';
-};
 
 -- Compile C and C++ source to object files.
 function gcc.compile( toolset, target, language )
@@ -213,7 +206,7 @@ function gcc.append_compile_flags( toolset, target, flags, language )
     local settings = toolset.settings;
 
     table.insert( flags, '-c' );
-    table.insert( flags, flags_by_architecture[settings.architecture] );
+    table.insert( flags, ('-march=%s'):format(settings.architecture) );
     table.insert( flags, '-fpic' );
     
     gcc.append_flags( flags, target.cppflags );
@@ -288,7 +281,7 @@ function gcc.append_link_flags( toolset, target, flags )
     gcc.append_flags( flags, settings.ldflags );
     gcc.append_flags( flags, target.ldflags );
 
-    table.insert( flags, flags_by_architecture[settings.architecture] );
+    table.insert( flags, ('-march=%s'):format(settings.architecture) );
     table.insert( flags, "-std=c++11" );
 
     if target:prototype() == toolset.DynamicLibrary then

--- a/src/forge/lua/forge/cc/gcc.lua
+++ b/src/forge/lua/forge/cc/gcc.lua
@@ -59,6 +59,7 @@ function gcc.initialize( toolset )
         run_time_type_info = true;
         standard = 'c++17';
         strip = false;
+        toolchain = 'gcc';
         verbose_linking = false;
         warning_level = 3;
         warnings_as_errors = true;

--- a/src/forge/lua/forge/cc/msvc.lua
+++ b/src/forge/lua/forge/cc/msvc.lua
@@ -313,6 +313,13 @@ function msvc.initialize( toolset )
         warnings_as_errors = true;
     };
 
+    -- Assume that 'native' architecture on Windows means x86_64.  This isn't
+    -- necessarily true but is more likely than i386 and any ARM variants.
+    local settings = toolset.settings;
+    if settings.architecture == 'native' then
+        settings.architecture = 'x86_64';
+    end
+
     return true;
 end
 

--- a/src/forge/lua/forge/cc/msvc.lua
+++ b/src/forge/lua/forge/cc/msvc.lua
@@ -307,6 +307,7 @@ function msvc.initialize( toolset )
         stack_size = 1048576;
         standard = 'c++17';
         subsystem = 'CONSOLE';
+        toolchain = 'msvc';
         verbose_linking = false;
         warning_level = 3;
         warnings_as_errors = true;


### PR DESCRIPTION
Tidy up the way that AES instruction sets are enabled as well as try and autodetect the architecture of the host machine at least on Linux systems.  This feels like host architecture might need to be a Forge API function as macOS is also potentially both x86_64 and armv8 now too.