### PR TITLE
Compile release for generic x86-64 architecture

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         if [[ "$RUNNER_OS" == "macOS" ]]; then bash ./bootstrap-macos.bash ; fi
         if [[ "$RUNNER_OS" == "Windows" ]]; then ./bootstrap-windows.bat ; fi
         bootstrap/bin/forge
-        debug/bin/forge variant=release prefix=forge install
+        debug/bin/forge architecture=x86-64 variant=release prefix=forge install
       shell: bash
     - name: Test
       run: |

--- a/forge.lua
+++ b/forge.lua
@@ -5,6 +5,7 @@
 package.path = root('src/forge/lua/?.lua')..';'..root('src/forge/lua/?/init.lua');
 
 variant = variant or 'debug';
+architecture = architecture or 'native';
 
 local cc = require 'forge.cc' {
     identifier = 'cc_${platform}_${architecture}';
@@ -25,7 +26,7 @@ local cc = require 'forge.cc' {
         ('BUILD_VARIANT_%s'):format( upper(variant) );
     };
 
-    architecture = 'native';
+    architecture = architecture;
     assertions = variant ~= 'shipping';
     debug = variant ~= 'shipping';
     debuggable = variant ~= 'shipping';

--- a/src/forge/lua/forge/cc/clang.lua
+++ b/src/forge/lua/forge/cc/clang.lua
@@ -236,11 +236,7 @@ function clang.append_compile_flags( toolset, target, flags, language )
     table.insert( flags, '-c' );
     table.insert( flags, '-fasm-blocks' );
 
-    local architecture = settings.architecture;
-    if architecture ~= 'native' then
-        table.insert( flags, ('-arch %s'):format(architecture) );
-    end
-
+    clang.append_arch_flags( flags, settings.architecture );
     clang.append_flags( flags, target.cppflags );
     clang.append_flags( flags, settings.cppflags );
     
@@ -330,16 +326,21 @@ function clang.append_library_directories( toolset, target, flags )
     clang.append_flags( flags, toolset.settings.library_directories, '-L "%s"' );
 end
 
+function clang.append_arch_flags( flags, architecture )
+    if architecture ~= 'native' then
+        if architecture == 'x86-64' then
+            architecture = 'x86_64';
+        end
+        table.insert( flags, ('-arch %s'):format(architecture) );
+    end
+end
+
 function clang.append_link_flags( toolset, target, flags )
     local settings = toolset.settings;
 
+    clang.append_arch_flags( flags, settings.architecture );
     clang.append_flags( flags, settings.ldflags );
     clang.append_flags( flags, target.ldflags );
-
-    local architecture = settings.architecture;
-    if architecture ~= 'native' then
-        table.insert( flags, ('-arch %s'):format(architecture) );
-    end
 
     local standard = settings.standard;
     if standard then 

--- a/src/forge/lua/forge/cc/msvc.lua
+++ b/src/forge/lua/forge/cc/msvc.lua
@@ -256,7 +256,7 @@ function msvc.initialize( toolset )
             SYSTEMROOT = os.getenv( 'SYSTEMROOT' );
             TMP = os.getenv( 'TMP' );
         };
-        ['x86_64'] = {
+        ['x86-64'] = {
             PATH = table.concat( path_x86_64, ';' );
             LIB = table.concat( lib_x86_64, ';' );
             LIBPATH = table.concat( lib_x86_64, ';' );
@@ -292,7 +292,7 @@ function msvc.initialize( toolset )
     toolset.Executable = Executable;
 
     toolset:defaults {
-        architecture = 'x86_64';
+        architecture = 'x86-64';
         assertions = true;
         debug = true;
         exceptions = true;
@@ -317,7 +317,7 @@ function msvc.initialize( toolset )
     -- necessarily true but is more likely than i386 and any ARM variants.
     local settings = toolset.settings;
     if settings.architecture == 'native' then
-        settings.architecture = 'x86_64';
+        settings.architecture = 'x86-64';
     end
 
     return true;
@@ -533,13 +533,13 @@ function msvc.visual_cxx_tool( toolset, tool )
     local settings = toolset.settings;
     local msvc = settings.msvc;
     if msvc.toolset_version >= 15 then 
-        if settings.architecture == 'x86_64' then
+        if settings.architecture == 'x86-64' then
             return ('%s\\bin\\Hostx64\\x64\\%s'):format( msvc.visual_cxx_directory, tool );
         else
             return ('%s\\bin\\Hostx64\\x86\\%s'):format( msvc.visual_cxx_directory, tool );
         end
     else
-        if settings.architecture == 'x86_64' then
+        if settings.architecture == 'x86-64' then
             return ('%s/VC/bin/amd64/%s'):format( msvc.visual_studio_directory, tool );
         else
             return ('%s/VC/bin/%s'):format( msvc.visual_studio_directory, tool );


### PR DESCRIPTION
This is to, hopefully, avoid illegal instruction errors that are now occasionally appearing on Github Actions runs that use the Forge official release.  Theory is that there are some different and incompatible processors running Github Actions that means that Forge built to match the architecture of one virtual machine isn't compatible with all other virtual machines.
