### PR TITLE
Fix transitive dependency problems

### DIFF
--- a/src/forge/Scheduler.cpp
+++ b/src/forge/Scheduler.cpp
@@ -359,7 +359,7 @@ int Scheduler::preorder( Target* target, int function )
         {
             SWEET_ASSERT( target );
 
-            if ( !target->visited() )
+            if ( target->referenced_by_script() && target->working_directory() && !target->visited() )
             {
                 ScopedVisit scoped_visit( target );
                 if ( scheduler_->preorder_visit(function_, target) )

--- a/src/forge/forge_test/transitive_dependencies.lua
+++ b/src/forge/forge_test/transitive_dependencies.lua
@@ -1,115 +1,31 @@
 
+require 'forge';
+local cc = require 'forge.cc' {};
 
-local executions = {};
-
-local function clear_executions()
-    executions = {};
-end
-
-local function print_executions()
-    for _, execution in ipairs(executions) do
-        printf( '%s', execution );
-    end
-    printf( '\n\n' );
-end
-
-local function execute( command, command_line )
-    table.insert( executions, ('%s %s'):format(command, command_line) );
-    return 0;
-end
-
-local function printf()
-end
-
-local function dependency_graph( toolset )
-    forge:reload();
-    local exe = toolset:Executable 'exe' {
-        toolset:StaticLibrary 'foo' {
+TestSuite {
+    transitive_dependencies_found = function()
+        local exe = cc:Executable 'exe' {
+            'foo';
             'baz';
-            toolset:StaticLibrary 'bar' {
-                toolset:StaticLibrary 'baz' {
-                    toolset:Cc 'baz.o' {
-                        'baz.c';
-                    };
-                };
-                toolset:Cc 'bar.o' {
-                    'bar.c';
-                };
-            };
-            toolset:Cc 'foo.o' {
-                'foo.c';
-            };
         };
-        toolset:Cc 'exe.o' {
-            'exe.c';
+        local foo = cc:StaticLibrary 'foo' {
+            'bar';
         };
-    };
-    clear_executions();
-    _G.execute = execute;
-    _G.printf = printf;
-    _G.find_initial_target = function() return exe end;
-    _G.goal = tostring( exe );
-    build();
-    forge:save();
-    return exe;
-end
+        local bar = cc:StaticLibrary 'bar' {
+            'baz';
+        };
+        local baz = cc:StaticLibrary 'baz' {            
+        };
 
-remove( absolute('.forge') );
+        CHECK( exe:dependency(1) == foo );
+        CHECK( exe:dependency(2) == baz );
+        CHECK( exe:dependency(3) == nil );
 
-if operating_system() == 'linux' then
-    require 'forge';
-    local cc = require 'forge.cc' {};
+        prepare( exe );
 
-    create( absolute('baz.o.o'), 1 );
-    create( absolute('libbaz.a'), 1 );
-    create( absolute('bar.c'), 1 );
-    create( absolute('bar.o.o'), 1 );
-    create( absolute('libbar.a'), 1 );
-    create( absolute('foo.o.o'), 1 );
-    create( absolute('libfoo.a'), 1 );
-    create( absolute('exe.o.o'), 1 );
-    create( absolute('exe'), 1 );
-
-    local exe = dependency_graph( cc );
-    CHECK( find_initial_target() == exe );
-    CHECK( #executions == 8 );
-    CHECK( executions[1] and executions[1]:find('gcc') );
-    CHECK( executions[2] and executions[2]:find('gcc') );
-    CHECK( executions[3] and executions[3]:find('ar') );
-    CHECK( executions[4] and executions[4]:find('gcc') );
-    CHECK( executions[5] and executions[5]:find('ar') );
-    CHECK( executions[6] and executions[6]:find('ar') );
-    CHECK( executions[7] and executions[7]:find('gcc') );
-    CHECK( executions[8] and executions[8]:find('g++') );
-
-    touch( absolute('bar.c'), 2 );
-
-    local exe = dependency_graph( cc );
-    CHECK( #executions == 8 );
-    CHECK( executions[1] and executions[1]:find('gcc') );
-    CHECK( executions[2] and executions[2]:find('gcc') );
-    CHECK( executions[3] and executions[3]:find('ar') );
-    CHECK( executions[4] and executions[4]:find('gcc') );
-    CHECK( executions[5] and executions[5]:find('ar') );
-    CHECK( executions[6] and executions[6]:find('ar') );
-    CHECK( executions[7] and executions[7]:find('gcc') );
-    CHECK( executions[8] and executions[8]:find('g++') );
-
-    touch( absolute('bar.o.o'), 2 );
-    touch( absolute('baz.o.o'), 2 );
-    touch( absolute('foo.o.o'), 2 );
-    touch( absolute('libbar.a'), 2 );
-    touch( absolute('libfoo.a'), 2 );
-    touch( absolute('exe'), 2 );
-
-    local exe = dependency_graph( cc );
-    CHECK( #executions == 6 );
-    CHECK( executions[1] and executions[1]:find('gcc') );
-    CHECK( executions[2] and executions[2]:find('gcc') );
-    CHECK( executions[3] and executions[3]:find('ar') );
-    CHECK( executions[4] and executions[4]:find('ar') );
-    CHECK( executions[5] and executions[5]:find('gcc') );
-    CHECK( executions[6] and executions[6]:find('g++') );
-
-    remove( absolute('.forge') );
-end
+        CHECK( exe:dependency(1) == foo );
+        CHECK( exe:dependency(2) == bar );
+        CHECK( exe:dependency(3) == baz );
+        CHECK( exe:dependency(4) == nil );
+    end;
+};

--- a/src/forge/lua/forge/init.lua
+++ b/src/forge/lua/forge/init.lua
@@ -93,14 +93,18 @@ end
 
 -- Provide global dependencies command.
 function dependencies()
-    print_dependencies( find_initial_target(goal) );
-    return 0;
+    local target = find_initial_target( goal );
+    local failures = prepare( target );
+    print_dependencies( target );
+    return failures;
 end
 
 -- Provide global namespace command.
 function namespace()
-    print_namespace( find_initial_target(goal) );
-    return 0;
+    local target = find_initial_target( goal );
+    local failures = prepare( target );
+    print_namespace( target );
+    return failures;
 end
 
 -- Provide global help command.

--- a/src/forge/lua/forge/init.lua
+++ b/src/forge/lua/forge/init.lua
@@ -62,10 +62,16 @@ function build_visit( target )
     end
 end
 
+-- Prepare dependency graph by propagating transitive dependencies.
+function prepare( target )
+    local failures = preorder( target, prepare_visit );
+    return failures;
+end
+
 -- Provide global build command.
 function build()
     local target = find_initial_target( goal );
-    local failures = preorder( target, prepare_visit ) + postorder( target, build_visit );
+    local failures = prepare( target ) + postorder( target, build_visit );
     forge:save();
     printf( "forge: default (build)=%dms", math.ceil(ticks()) );
     return failures;


### PR DESCRIPTION
- Stop visiting targets without working directories or Lua bindings on `preorder()`
- Reorder dependencies at the same level or weaker not just weaker
