### PR TITLE
Rename transitive dependencies to passive

### DIFF
--- a/docs/reference/target.md
+++ b/docs/reference/target.md
@@ -330,30 +330,6 @@ function Target.dependencies( target, start, finish )
 
 Iterate over the explicit dependencies of `target`.  The `start` and `finish` parameters are optional and default to 1 and `INT_MAX` respectively to give the effect of iterating over all the explicit dependencies of `target`.
 
-### implicit_dependency
-
-~~~lua
-function Target.implicit_dependency( target, n )
-~~~
-
-Return the `n`th implicit dependency of `target` or nil if `n` is greater than the number of dependencies of `target.`
-
-### implicit_dependencies
-
-~~~lua
-function Target.implicit_dependencies( target )
-~~~
-
-Iterate over the implicit dependencies of `target`.  The `start` and `finish` parameters are optional and default to 1 and `INT_MAX` respectively to give the effect of iterating over all the implicit dependencies of `target`.
-
-### ordering_dependency
-
-~~~lua
-function Target.ordering_dependency( target )
-~~~
-
-Return the `n`th ordering dependency of `target`.  Nil is returned if `n` is greater than the number of ordering dependencies of `target`.
-
 ### ordering_dependencies
 
 ~~~lua
@@ -362,18 +338,10 @@ function Target.ordering_dependencies( target )
 
 Iterate over the ordering dependencies of `target`.  The `start` and `finish` parameters are optional and default to 1 and `INT_MAX` respectively to give the effect of iterating over all the ordering dependencies of `target`.
 
-### any_dependency
-
-~~~lua
-function Target.any_dependency( target )
-~~~
-
-Return the `n`th dependency of `target` considering dependencies of all types ordered by explicit, implicit, and ordering.  Nil is returned if `n` is greater than the total number of dependencies of `target`.
-
 ### any_dependencies
 
 ~~~lua
-function Target.any_dependencies( target )
+function Target.all_dependencies( target )
 ~~~
 
 Iterate over all dependencies of `target`.  The `start` and `finish` parameters are optional and default to 1 and `INT_MAX` respectively to give the effect of iterating over all dependencies of `target`.

--- a/docs/reference/target.md
+++ b/docs/reference/target.md
@@ -238,7 +238,13 @@ The working directory is the target that specifies the directory that files spec
 function Target.add_dependency( target, dependency )
 ~~~
 
-Add `dependency` as an explicit dependency of `target`.  Cyclic dependencies are not valid but are not reported by this function.  If a cyclic dependency is detected during a traversal then it is silently ignored.  If `dependency` is nil then this function will silently do nothing.
+Add `dependency` as an explicit dependency of `target`.
+
+If `dependency` is null or the same as `target` then this function quietly does nothing.
+
+If `dependency` is already an implicit, ordering, or passive dependency of `target` then it is made the last explicit dependency of `target`.  That is the dependency is removed and added as the last explicit dependency.
+
+Cyclic dependencies are not valid but are not reported here.  Cyclic dependencies are detected during traversals and silently ignored.
 
 ### remove_dependency
 
@@ -246,7 +252,7 @@ Add `dependency` as an explicit dependency of `target`.  Cyclic dependencies are
 function Target.remove_dependency( target, dependency )
 ~~~
 
-Remove `dependency` as a dependency of `target`.  Removes the dependency regardless of whether that dependency is explicit, implicit, and ordering dependencies.
+Remove `dependency` as a dependency of `target`.  Removes the dependency regardless of whether that dependency is an explicit, implicit, ordering, or passive dependency.
 
 ### add_implicit_dependency
 
@@ -255,6 +261,10 @@ function Target.add_implicit_dependency( target, dependency )
 ~~~
 
 Add `dependency` as an implicit dependency of `target`.
+
+If `dependency` is null, the same as `target`, anonymous, or already an explicit dependency of `target` then this function quietly does nothing.
+
+If `dependency` is already an implicit, ordering, or passive dependency of `target` then it is made the last implicit dependency of `target`.  That is the dependency is removed and added as the last implicit dependency.
 
 ### clear_implicit_dependencies
 
@@ -271,6 +281,22 @@ function Target.add_ordering_dependency( target, dependency )
 ~~~
 
 Add `dependency` as an ordering dependency of `target`.
+
+If `dependency` is null, the same as `target`, anonymous, or already an explicit or implicit dependency of `target` then this function quietly does nothing.
+
+If `dependency` is already an ordering or passive dependency of `target` then it is made the last ordering dependency of `target`.  That is the dependency is removed and added as the last ordering dependency.
+
+### add_passive_dependency
+
+~~~lua
+function Target.add_passive_dependency( target, dependency )
+~~~
+
+Add `dependency` as a passive dependency of `target`.
+
+If `dependency` is null, the same as `target`, anonymous, or already an explicit, implicit, or ordering dependency of `target` then this function quietly does nothing.
+
+If `dependency` is already a passive dependency of `target` then it is made the last passive dependency of `target`.  That is the dependency is removed and added as the last passive dependency.
 
 ### parent
 

--- a/src/forge/Target.cpp
+++ b/src/forge/Target.cpp
@@ -31,8 +31,8 @@ Target::Target()
 : id_(),
   path_(),
   branch_(),
-  graph_( NULL ),
-  prototype_( NULL ),
+  graph_( nullptr ),
+  prototype_( nullptr ),
   timestamp_( 0 ),
   last_write_time_( 0 ),
   hash_( 0 ),
@@ -44,8 +44,8 @@ Target::Target()
   referenced_by_script_( false ),
   cleanable_( false ),
   built_( false ),
-  working_directory_( NULL ),
-  parent_( NULL ),
+  working_directory_( nullptr ),
+  parent_( nullptr ),
   targets_(),
   dependencies_(),
   implicit_dependencies_(),
@@ -74,7 +74,7 @@ Target::Target( const std::string& id, Graph* graph )
   path_(),
   branch_(),
   graph_( graph ),
-  prototype_( NULL ),
+  prototype_( nullptr ),
   timestamp_( 0 ),
   last_write_time_( 0 ),
   hash_( 0 ),
@@ -86,8 +86,8 @@ Target::Target( const std::string& id, Graph* graph )
   referenced_by_script_( false ),
   cleanable_( false ),
   built_( false ),
-  working_directory_( NULL ),
-  parent_( NULL ),
+  working_directory_( nullptr ),
+  parent_( nullptr ),
   targets_(),
   dependencies_(),
   implicit_dependencies_(),
@@ -126,7 +126,7 @@ Target::~Target()
 void Target::recover( Graph* graph )
 {
     SWEET_ASSERT( graph );    
-    SWEET_ASSERT( graph_ == NULL || graph_ == graph );
+    SWEET_ASSERT( graph_ == nullptr || graph_ == graph );
 
     graph_ = graph;
 
@@ -754,10 +754,10 @@ void Target::destroy_anonymous_targets()
         if ( target->anonymous() )
         {
             delete target;
-            *i = NULL;
+            *i = nullptr;
         }
     }
-    targets_.erase( remove(targets_.begin(), targets_.end(), (Target*) NULL), targets_.end() );
+    targets_.erase( remove(targets_.begin(), targets_.end(), (Target*) nullptr), targets_.end() );
 }
 
 /**
@@ -776,7 +776,7 @@ Target* Target::find_target_by_id( const std::string& id ) const
     {
         ++i;
     }
-    return i != targets_.end() ? *i : NULL;
+    return i != targets_.end() ? *i : nullptr;
 }
 
 /**
@@ -1101,7 +1101,7 @@ Target* Target::explicit_dependency( int n ) const
     {
         return dependencies_[n];
     }
-    return NULL;
+    return nullptr;
 }
 
 /**
@@ -1121,7 +1121,7 @@ Target* Target::implicit_dependency( int n ) const
     {
         return implicit_dependencies_[n];
     }
-    return NULL;
+    return nullptr;
 }
 
 /**
@@ -1141,7 +1141,7 @@ Target* Target::ordering_dependency( int n ) const
     {
         return ordering_dependencies_[n];
     }
-    return NULL;
+    return nullptr;
 }
 
 /**
@@ -1232,7 +1232,7 @@ bool Target::buildable() const
         ++i;
         target = any_dependency( i );
     }
-    return target == NULL;
+    return target == nullptr;
 }
 
 /**
@@ -1278,7 +1278,7 @@ std::string Target::failed_dependencies() const
     {
         message += "'" + id() + "'";
     }
-    else if ( prototype() != NULL )
+    else if ( prototype() != nullptr )
     {
         message += prototype()->id();
     }

--- a/src/forge/Target.cpp
+++ b/src/forge/Target.cpp
@@ -28,35 +28,35 @@ using namespace sweet::forge;
 // Constructor.
 */
 Target::Target()
-: id_(),
-  path_(),
-  branch_(),
-  graph_( nullptr ),
-  prototype_( nullptr ),
-  timestamp_( 0 ),
-  last_write_time_( 0 ),
-  hash_( 0 ),
-  pending_hash_( 0 ),
-  outdated_( false ),
-  changed_( false ),
-  bound_to_file_( false ),
-  bound_to_dependencies_( false ),
-  referenced_by_script_( false ),
-  cleanable_( false ),
-  built_( false ),
-  working_directory_( nullptr ),
-  parent_( nullptr ),
-  targets_(),
-  dependencies_(),
-  implicit_dependencies_(),
-  ordering_dependencies_(),
-  passive_dependencies_(),
-  filenames_(),
-  visiting_( false ),
-  visited_revision_( 0 ),
-  successful_revision_( 0 ),
-  postorder_height_( -1 ),
-  anonymous_( 0 )
+: id_()
+, path_()
+, branch_()
+, graph_( nullptr )
+, prototype_( nullptr )
+, timestamp_( 0 )
+, last_write_time_( 0 )
+, hash_( 0 )
+, pending_hash_( 0 )
+, outdated_( false )
+, changed_( false )
+, bound_to_file_( false )
+, bound_to_dependencies_( false )
+, referenced_by_script_( false )
+, cleanable_( false )
+, built_( false )
+, working_directory_( nullptr )
+, parent_( nullptr )
+, targets_()
+, dependencies_()
+, implicit_dependencies_()
+, ordering_dependencies_()
+, passive_dependencies_()
+, filenames_()
+, visiting_( false )
+, visited_revision_( 0 )
+, successful_revision_( 0 )
+, postorder_height_( -1 )
+, anonymous_( 0 )
 {
 }
 
@@ -70,34 +70,34 @@ Target::Target()
 //  The Graph that this Target is part of.
 */
 Target::Target( const std::string& id, Graph* graph )
-: id_( id ),
-  path_(),
-  branch_(),
-  graph_( graph ),
-  prototype_( nullptr ),
-  timestamp_( 0 ),
-  last_write_time_( 0 ),
-  hash_( 0 ),
-  pending_hash_( 0 ),
-  outdated_( false ),
-  changed_( false ),
-  bound_to_file_( false ),
-  bound_to_dependencies_( false ),
-  referenced_by_script_( false ),
-  cleanable_( false ),
-  built_( false ),
-  working_directory_( nullptr ),
-  parent_( nullptr ),
-  targets_(),
-  dependencies_(),
-  implicit_dependencies_(),
-  ordering_dependencies_(),
-  filenames_(),
-  visiting_( false ),
-  visited_revision_( 0 ),
-  successful_revision_( 0 ),
-  postorder_height_( -1 ),
-  anonymous_( 0 )
+: id_( id )
+, path_()
+, branch_()
+, graph_( graph )
+, prototype_( nullptr )
+, timestamp_( 0 )
+, last_write_time_( 0 )
+, hash_( 0 )
+, pending_hash_( 0 )
+, outdated_( false )
+, changed_( false )
+, bound_to_file_( false )
+, bound_to_dependencies_( false )
+, referenced_by_script_( false )
+, cleanable_( false )
+, built_( false )
+, working_directory_( nullptr )
+, parent_( nullptr )
+, targets_()
+, dependencies_()
+, implicit_dependencies_()
+, ordering_dependencies_()
+, filenames_()
+, visiting_( false )
+, visited_revision_( 0 )
+, successful_revision_( 0 )
+, postorder_height_( -1 )
+, anonymous_( 0 )
 {
     SWEET_ASSERT( !id_.empty() );
     SWEET_ASSERT( graph_ );

--- a/src/forge/Target.cpp
+++ b/src/forge/Target.cpp
@@ -50,7 +50,7 @@ Target::Target()
   dependencies_(),
   implicit_dependencies_(),
   ordering_dependencies_(),
-  transitive_dependencies_(),
+  passive_dependencies_(),
   filenames_(),
   visiting_( false ),
   visited_revision_( 0 ),
@@ -931,35 +931,35 @@ void Target::clear_ordering_dependencies()
 }
 
 /**
-// Add a transitive dependency to this Target.
+// Add a passive dependency to this Target.
 //
 // @param target
-//  The Target to add as a transitive dependency (quietly ignored if null,
+//  The Target to add as a passive dependency (quietly ignored if null,
 //  the same as this target, or already an explicit, implicit, or ordering
 //  dependency).
 */
-void Target::add_transitive_dependency( Target* target )
+void Target::add_passive_dependency( Target* target )
 {
-    bool able_to_transitive_dependency_add = 
+    bool able_to_passive_dependency_add = 
         target &&
         target != this &&
         !is_explicit_dependency( target ) &&
         !is_implicit_dependency( target ) &&
         !is_ordering_dependency( target )
     ;
-    if ( able_to_transitive_dependency_add )
+    if ( able_to_passive_dependency_add )
     {
         remove_dependency( target );
-        transitive_dependencies_.push_back( target );
+        passive_dependencies_.push_back( target );
     }
 }
 
 /**
-// Clear all transitive dependencies.
+// Clear all passive dependencies.
 */
-void Target::clear_transitive_dependencies()
+void Target::clear_passive_dependencies()
 {
-    transitive_dependencies_.clear();
+    passive_dependencies_.clear();
 }
 
 /**
@@ -969,7 +969,7 @@ void Target::clear_transitive_dependencies()
 // function silently does nothing.
 //
 // Targets are removed from this Target's explicit, implicit, ordering, and
-// transitive dependencies.
+// passive dependencies.
 //
 // If an explicit or implicit dependency is removed then the the bound to 
 // dependencies flag for this Target is cleared to indicate that the outdated
@@ -1006,10 +1006,10 @@ void Target::remove_dependency( Target* target )
                 }
                 else
                 {
-                    i = find( transitive_dependencies_.begin(), transitive_dependencies_.end(), target );
-                    if ( i != transitive_dependencies_.end() )
+                    i = find( passive_dependencies_.begin(), passive_dependencies_.end(), target );
+                    if ( i != passive_dependencies_.end() )
                     {
-                        transitive_dependencies_.erase( i );
+                        passive_dependencies_.erase( i );
                     }
                 }
             }
@@ -1059,9 +1059,9 @@ bool Target::is_ordering_dependency( Target* target ) const
     return find( ordering_dependencies_.begin(), ordering_dependencies_.end(), target ) != ordering_dependencies_.end();
 }
 
-bool Target::is_transitive_dependency( Target* target ) const
+bool Target::is_passive_dependency( Target* target ) const
 {
-    return find( transitive_dependencies_.begin(), transitive_dependencies_.end(), target ) != transitive_dependencies_.end();
+    return find( passive_dependencies_.begin(), passive_dependencies_.end(), target ) != passive_dependencies_.end();
 }
 
 /**
@@ -1080,7 +1080,7 @@ bool Target::is_dependency( Target* target ) const
         is_explicit_dependency( target ) ||
         is_implicit_dependency( target ) ||
         is_ordering_dependency( target ) ||
-        is_transitive_dependency( target )
+        is_passive_dependency( target )
     ;
 }
 
@@ -1145,21 +1145,21 @@ Target* Target::ordering_dependency( int n ) const
 }
 
 /**
-// Get the nth transitive dependency of this Target.
+// Get the nth passive dependency of this Target.
 //
 // @param n
-//  The index of the transitive dependency to return (assumed >= 0).
+//  The index of the passive dependency to return (assumed >= 0).
 //
 // @return
-//  The nth transitive dependency of this Target or null if 'n' is outside the
-//  range of transitive dependencies.
+//  The nth passive dependency of this Target or null if 'n' is outside the
+//  range of passive dependencies.
 */
-Target* Target::transitive_dependency( int n ) const
+Target* Target::passive_dependency( int n ) const
 {
     SWEET_ASSERT( n >= 0 );
-    if ( n >= 0 && n < int(transitive_dependencies_.size()) )
+    if ( n >= 0 && n < int(passive_dependencies_.size()) )
     {
-        return transitive_dependencies_[n];
+        return passive_dependencies_[n];
     }
     return nullptr;
 }
@@ -1209,9 +1209,9 @@ Target* Target::any_dependency( int n ) const
     }
 
     n -= int(ordering_dependencies_.size());
-    if ( n >= 0 && n < int(transitive_dependencies_.size()) )
+    if ( n >= 0 && n < int(passive_dependencies_.size()) )
     {
-        return transitive_dependencies_[n];
+        return passive_dependencies_[n];
     }
 
     return nullptr;

--- a/src/forge/Target.hpp
+++ b/src/forge/Target.hpp
@@ -42,10 +42,10 @@ class Target
     Target* working_directory_; ///< The Target that relative paths expressed when this Target is visited are relative to.
     Target* parent_; ///< The parent of this Target in the Target namespace or null if this Target has no parent.
     std::vector<Target*> targets_; ///< The children of this Target in the Target namespace.
-    std::vector<Target*> dependencies_; ///< The Targets that this Target depends on.
-    std::vector<Target*> implicit_dependencies_; ///< The Targets that this Target implicitly depends on.
-    std::vector<Target*> ordering_dependencies_; ///< The Targets that must build before this Target is built.
-    std::vector<Target*> transitive_dependencies_; ///< The Targets that are transitive dependencies of this Target.
+    std::vector<Target*> dependencies_; ///< Explicit dependencies.
+    std::vector<Target*> implicit_dependencies_; ///< Implicit dependencies.
+    std::vector<Target*> ordering_dependencies_; ///< Targets that must build before this Target is built.
+    std::vector<Target*> passive_dependencies_; ///< Passive dependencies of this Target.
     std::vector<std::string> filenames_; ///< The filenames of this Target.
     bool visiting_; ///< Whether or not this Target is in the process of being visited.
     int visited_revision_; ///< The visited revision the last time this Target was visited.
@@ -118,18 +118,18 @@ class Target
         void clear_implicit_dependencies();
         void add_ordering_dependency( Target* target );
         void clear_ordering_dependencies();
-        void add_transitive_dependency( Target* target );
-        void clear_transitive_dependencies();
+        void add_passive_dependency( Target* target );
+        void clear_passive_dependencies();
         void remove_dependency( Target* target );
         bool is_explicit_dependency( Target* target ) const;
         bool is_implicit_dependency( Target* target ) const;
         bool is_ordering_dependency( Target* target ) const;
-        bool is_transitive_dependency( Target* target ) const;
+        bool is_passive_dependency( Target* target ) const;
         bool is_dependency( Target* target ) const;
         Target* explicit_dependency( int n ) const;
         Target* implicit_dependency( int n ) const;
         Target* ordering_dependency( int n ) const;
-        Target* transitive_dependency( int n ) const;
+        Target* passive_dependency( int n ) const;
         Target* any_dependency( int n ) const;
 
         bool buildable() const;

--- a/src/forge/forge_lua/LuaTarget.cpp
+++ b/src/forge/forge_lua/LuaTarget.cpp
@@ -72,7 +72,7 @@ void LuaTarget::create( lua_State* lua_state, Forge* forge )
         { "add_implicit_dependency", &LuaTarget::add_implicit_dependency },
         { "clear_implicit_dependencies", &LuaTarget::clear_implicit_dependencies },
         { "add_ordering_dependency", &LuaTarget::add_ordering_dependency },
-        { "add_transitive_dependency", &LuaTarget::add_transitive_dependency },
+        { "add_passive_dependency", &LuaTarget::add_passive_dependency },
         { nullptr, nullptr }
     };
     luaxx_push( lua_state_, this );
@@ -597,7 +597,7 @@ int LuaTarget::add_ordering_dependency( lua_State* lua_state )
     return 0;
 }
 
-int LuaTarget::add_transitive_dependency( lua_State* lua_state )
+int LuaTarget::add_passive_dependency( lua_State* lua_state )
 {
     const int TARGET = 1;
     const int DEPENDENCY = 2;
@@ -606,7 +606,7 @@ int LuaTarget::add_transitive_dependency( lua_State* lua_state )
     if ( target )
     {
         Target* dependency = (Target*) luaxx_to( lua_state, DEPENDENCY, TARGET_TYPE );
-        target->add_transitive_dependency( dependency );
+        target->add_passive_dependency( dependency );
     }
     return 0;
 }

--- a/src/forge/forge_lua/LuaTarget.hpp
+++ b/src/forge/forge_lua/LuaTarget.hpp
@@ -57,7 +57,7 @@ public:
     static int add_implicit_dependency( lua_State* lua_state );
     static int clear_implicit_dependencies( lua_State* lua_state );
     static int add_ordering_dependency( lua_State* lua_state );
-    static int add_transitive_dependency( lua_State* lua_state );
+    static int add_passive_dependency( lua_State* lua_state );
     static int all_dependencies_iterator( lua_State* lua_state );
     static int all_dependencies( lua_State* lua_state );
     static int explicit_dependency( lua_State* lua_state );

--- a/src/forge/lua/forge/cc/init.lua
+++ b/src/forge/lua/forge/cc/init.lua
@@ -6,7 +6,7 @@ local cc = {};
 -- Collect transitive static library dependencies.
 --
 -- Walks dependencies from executables and dynamic libraries to find
--- transitive dependencies specified as dependencies of static
+-- transitive dependencies specified as passive dependencies of static
 -- libraries.  Those transitive libraries are made dependencies of the
 -- executable or dynamic library at the root of the walk.
 --
@@ -36,11 +36,12 @@ function cc.collect_transitive_dependencies( toolset, target )
     prune();
 end
 
--- Implement depend() with transitive dependencies for static libraries.
+-- Implement depend() for transitive dependencies on static libraries.
 --
 -- Dependencies with StaticLibrary prototypes or no prototypes are added as
--- transitive dependencies.  Other dependencies are added as normal
--- dependencies.
+-- passive dependencies to be propagated to binaries in the prepare pass
+-- before the build runs.  Other dependencies (e.g. object files) are added
+-- as normal dependencies.
 function cc.static_library_depend( toolset, target, dependencies )
     assert( type(dependencies) == 'table', 'Target.depend() parameter not a table as expected' );
     forge:merge( target, dependencies );
@@ -48,7 +49,7 @@ function cc.static_library_depend( toolset, target, dependencies )
         local dependency = toolset:SourceFile( value );
         local prototype = dependency:prototype();
         if prototype == nil or prototype == toolset.StaticLibrary then
-            target:add_transitive_dependency( dependency );
+            target:add_passive_dependency( dependency );
         else
             target:add_dependency( dependency );
         end


### PR DESCRIPTION
Documenting transitive dependencies was difficult with Forge's transitive-type dependencies being named the same thing.  Renaming transitive-type dependencies to passive dependencies avoids that confusion and passive dependencies better matches their actual behavior, rather than just one of their uses.