### PR TITLE
Make forge:load() call explicit

### DIFF
--- a/forge.lua
+++ b/forge.lua
@@ -7,7 +7,7 @@ package.path = root('src/forge/lua/?.lua')..';'..root('src/forge/lua/?/init.lua'
 variant = variant or 'debug';
 architecture = architecture or 'native';
 
-local forge = require 'forge';
+local forge = require( 'forge' ):load( variant );
 
 local toolset = forge.Toolset {
     identifier = 'cc_${platform}_${architecture}';

--- a/src/forge/lua/forge/Toolset.lua
+++ b/src/forge/lua/forge/Toolset.lua
@@ -2,10 +2,11 @@
 local Toolset = _G.Toolset or {};
 
 function Toolset.new( _, values )
-    local forge = require( 'forge' ):load( values );
+    local local_settings = require( 'forge' ).local_settings;
+    assertf( local_settings, 'missing local settings' );
     local identifier = Toolset.interpolate( Toolset, values and values.identifier or '', values );
     local toolset = add_toolset( identifier );
-    apply( toolset, forge.local_settings );
+    apply( toolset, local_settings );
     apply( toolset, values );
     return toolset;
 end
@@ -38,11 +39,12 @@ function Toolset:defaults( values )
 end
 
 function Toolset:configure_once( id, configure )
-    local local_settings = forge.local_settings;
+    local local_settings = require( 'forge' ).local_settings;
+    assertf( local_settings, 'missing local settings' );
     local settings = local_settings[id];
     if not settings then
-        local project_settings = self[id] or {};
-        settings = configure( self, project_settings );
+        local module_settings = self[id] or {};
+        settings = configure( self, module_settings );
         self[id] = settings;
         local_settings[id] = settings;
         local_settings.updated = true;

--- a/src/forge/lua/forge/init.lua
+++ b/src/forge/lua/forge/init.lua
@@ -549,14 +549,6 @@ function forge:save()
     save_binary();
 end
 
-setmetatable( forge, {
-    __call = function( _, variables )
-        local forge = require( 'forge' ):load();
-        local toolset = Toolset( forge.local_settings );
-        return toolset:clone( variables );
-    end
-} );
-
 forge.Toolset = require 'forge.Toolset';
 
 return forge;

--- a/src/forge/lua/forge/init.lua
+++ b/src/forge/lua/forge/init.lua
@@ -481,12 +481,19 @@ end
 -- directory of the project if it exists or set to an empty table otherwise.
 --
 -- Returns self
-function forge:load()
+function forge:load( cache_directory )
     if not self.loaded then
-        local variant = _G.variant or self.variant;
+        if cache_directory then
+            local local_settings = root( ('%s/local_settings.lua'):format(cache_directory) );
+            self.cache_directory = cache_directory;
+            self.local_settings = exists( local_settings ) and dofile( local_settings ) or {};
+            self.cache = root( ('%s/.forge'):format(cache_directory) );
+        else
+            local local_settings = root( 'local_settings.lua' );
+            self.local_settings = exists( local_settings ) and dofile( local_settings ) or {};
+            self.cache = root( '.forge' );
+        end
         self.loaded = true;
-        self.local_settings = exists( root('local_settings.lua') ) and dofile( root('local_settings.lua') ) or {};
-        self.cache = variant and root( ('%s/.forge'):format(variant) ) or root( '.forge' );
         load_binary( self.cache );
     end
     return self;
@@ -539,7 +546,8 @@ function forge:save()
     local local_settings = self.local_settings;
     if local_settings and local_settings.updated then
         local_settings.updated = nil;
-        local filename = root( 'local_settings.lua' );
+        local cache_directory = self.cache_directory;
+        local filename = cache_directory and root( ('%s/local_settings.lua'):format(cache_directory) ) or root( 'local_settings.lua' );
         local file = io.open( filename, 'wb' );
         assertf( file, 'Opening "%s" to write settings failed', filename );
         serialize( file, local_settings, 0 );


### PR DESCRIPTION
Make the call to `forge:load()` explicit from `forge.lua`.  Pass in the output directory for the cache instead of depending on the global `variable`.  Also write local settings to the cache directory instead of the root directory, allowing local settings to be per-variant.