### PR TITLE
Allow yielding from preorder traversal

### DIFF
--- a/src/forge/ForgeEventSink.hpp
+++ b/src/forge/ForgeEventSink.hpp
@@ -1,5 +1,4 @@
-#ifndef FORGE_BUILDTOOLEVENTSINK_HPP_INCLUDED
-#define FORGE_BUILDTOOLEVENTSINK_HPP_INCLUDED
+#pragma once
 
 namespace sweet
 {
@@ -25,5 +24,3 @@ class ForgeEventSink
 }
 
 }
-
-#endif

--- a/src/forge/Job.cpp
+++ b/src/forge/Job.cpp
@@ -11,9 +11,10 @@ using namespace sweet;
 using namespace sweet::forge;
 
 Job::Job( Target* target, int height )
-: target_( target ),
-  height_( height ),
-  state_( JOB_WAITING )
+: target_( target )
+, height_( height )
+, state_( JOB_WAITING )
+, prune_( false )
 {
     SWEET_ASSERT( target_ );
     SWEET_ASSERT( height_ >= 0 );
@@ -43,6 +44,11 @@ JobState Job::state() const
     return state_;
 }
 
+bool Job::prune() const
+{
+    return prune_;
+}
+
 bool Job::operator<( const Job& job ) const
 {
     return height_ < job.height_;
@@ -52,4 +58,9 @@ void Job::set_state( JobState state )
 {
     SWEET_ASSERT( state >= JOB_WAITING && state <= JOB_COMPLETE );
     state_ = state;
+}
+
+void Job::set_prune( bool prune )
+{
+    prune_ = prune;
 }

--- a/src/forge/Job.hpp
+++ b/src/forge/Job.hpp
@@ -16,7 +16,7 @@ enum JobState
 {
     JOB_WAITING, ///< The Job is waiting in the queue.
     JOB_PROCESSING, ///< The Job is being processed.
-    JOB_COMPLETE ///< The Job has been processed.
+    JOB_COMPLETE ///< The Job is processed.
 };
 
 class Target;
@@ -30,17 +30,20 @@ class Job
     Target* target_; ///< The Target that this Job is for.
     int height_; ///< The height of this Job in its Graph.
     JobState state_; ///< The JobState of this Job.
+    bool prune_; ///< Was prune() called during this Job?
 
     public:
-        Job( Target* target, int height );
+        Job( Target* target, int height = 0 );
 
         Target* target() const;
         Target* working_directory() const;
         int height() const;
         JobState state() const;
+        bool prune() const;
         bool operator<( const Job& job ) const;
 
-        void set_state( JobState state );        
+        void set_state( JobState state );
+        void set_prune( bool prune );
 };
 
 }

--- a/src/forge/Scheduler.hpp
+++ b/src/forge/Scheduler.hpp
@@ -45,7 +45,6 @@ class Scheduler
     std::vector<Target*> buildfiles_stack_; ///< The stack of currently processing buildfiles.
     int pending_results_; ///< The number of results waiting on execute and read tasks to finish.
     int buildfile_calls_; ///< The number of outstanding calls made to load buildfiles.
-    int failures_; ///< The number of failures in the most recent postorder traversal.
 
     public:
         Scheduler( Forge* forge );
@@ -54,7 +53,7 @@ class Scheduler
         void script( const boost::filesystem::path& working_directory, const std::string& script );
         void command( const boost::filesystem::path& working_directory, const std::string& command );
         int buildfile( const boost::filesystem::path& path );
-        bool preorder_visit( int function, Target* target );
+        void preorder_visit( int function, Job* job );
         void postorder_visit( int function, Job* job );
         void execute_finished( int exit_code, Context* context, process::Environment* environment );
         void read_finished( Filter* filter, Arguments* arguments );

--- a/src/forge/Scheduler.hpp
+++ b/src/forge/Scheduler.hpp
@@ -43,8 +43,7 @@ class Scheduler
     std::condition_variable results_condition_; ///< The Condition that is used to wait for results.
     std::deque<std::function<void()> > results_; ///< The functions to be executed as a result of jobs processing in the thread pool.
     std::vector<Target*> buildfiles_stack_; ///< The stack of currently processing buildfiles.
-    int execute_jobs_; ///< The number of outstanding execute jobs.
-    int read_jobs_; ///< The number of outstanding read jobs.
+    int pending_results_; ///< The number of results waiting on execute and read tasks to finish.
     int buildfile_calls_; ///< The number of outstanding calls made to load buildfiles.
     int failures_; ///< The number of failures in the most recent postorder traversal.
 

--- a/src/forge/forge.forge
+++ b/src/forge/forge.forge
@@ -20,8 +20,10 @@ for _, cc in toolsets('cc.*') do
         '${lib}/boost_filesystem_${architecture}';
         '${lib}/boost_system_${architecture}';
         '${lib}/error_${architecture}';
-        '${lib}/process_${architecture}';
         '${lib}/forge_lua_${architecture}';
+        '${lib}/liblua_${platform}_${architecture}';
+        '${lib}/luaxx_${architecture}';
+        '${lib}/process_${architecture}';
 
         cc:Cxx '${obj}/%1' {
             defines = {

--- a/src/forge/forge/forge.forge
+++ b/src/forge/forge/forge.forge
@@ -23,16 +23,8 @@ for _, forge in toolsets('cc.*') do
 
     forge:all {
         forge:Executable '${bin}/forge' {
-            '${lib}/forge_${architecture}';
-            '${lib}/forge_lua_${architecture}';
-            '${lib}/process_${architecture}';
-            '${lib}/luaxx_${architecture}';
             '${lib}/cmdline_${architecture}';
-            '${lib}/error_${architecture}';
-            '${lib}/assert_${architecture}';
-            '${lib}/liblua_${platform}_${architecture}';
-            '${lib}/boost_filesystem_${architecture}';
-            '${lib}/boost_system_${architecture}';
+            '${lib}/forge_${architecture}';
 
             libraries = libraries;
             

--- a/src/forge/forge_test/FileChecker.hpp
+++ b/src/forge/forge_test/FileChecker.hpp
@@ -12,10 +12,11 @@ namespace sweet
 namespace forge
 {
 
-struct FileChecker : public ErrorChecker
+class FileChecker : public ErrorChecker
 {
     std::vector<std::string> files_;
     
+public:
     FileChecker();
     ~FileChecker();
     void create( const char* filename, const char* content, std::time_t last_write_time = 0 );

--- a/src/forge/forge_test/ForgeLuaFixture.cpp
+++ b/src/forge/forge_test/ForgeLuaFixture.cpp
@@ -1,0 +1,184 @@
+//
+// ForgeLuaFixture.cpp
+// Copyright (c) Charles Baker. All rights reserved.
+//
+
+#include "ForgeLuaFixture.hpp"
+#include "FileChecker.hpp"
+#include <forge/Forge.hpp>
+#include <error/ErrorPolicy.hpp>
+#include <luaxx/luaxx_unit/LuaUnitTest.hpp>
+#include <assert/assert.hpp>
+#include <lua.hpp>
+#include <UnitTest++/UnitTest++.h>
+#include <boost/filesystem/path.hpp>
+#include <boost/filesystem/operations.hpp>
+#include <string>
+
+using std::string;
+using namespace sweet;
+using namespace sweet::forge;
+using namespace luaxx;
+using namespace boost::filesystem;
+
+ForgeLuaFixture::ForgeLuaFixture()
+: forge( nullptr )
+, lua_unit_test( nullptr )
+, file_checker( nullptr )
+, show_errors( false )
+{
+    path path = boost::filesystem::path( string(TEST_DIRECTORY) );
+    forge = new forge::Forge( path.string(), *this, this );
+    lua_unit_test = new LuaUnitTest;
+    file_checker = new FileChecker;
+
+    forge->reset();
+    forge->set_root_directory( path.generic_string() );
+    forge->set_stack_trace_enabled( true );
+    forge->set_package_path(
+        forge->root("../lua/?.lua").generic_string() + ";" +
+        forge->root("../lua/?/init.lua").generic_string()
+    );
+
+    lua_unit_test->create( forge->lua_state(), this );
+
+    static const luaL_Reg file_functions [] = 
+    {
+        { "quiet", &ForgeLuaFixture::quiet },
+        { "verbose", &ForgeLuaFixture::verbose },
+        { "create", &ForgeLuaFixture::create },
+        { "remove", &ForgeLuaFixture::remove },
+        { "touch", &ForgeLuaFixture::touch },
+        { nullptr, nullptr }
+    };
+
+    lua_State* lua_state = forge->lua_state();
+    lua_pushglobaltable( lua_state );
+    lua_pushlightuserdata( lua_state, this );
+    luaL_setfuncs( lua_state, file_functions, 1 );    
+    lua_pop( lua_state, 1 );
+}
+
+ForgeLuaFixture::~ForgeLuaFixture()
+{
+    delete file_checker;
+    delete lua_unit_test;
+    delete forge;
+}
+
+void ForgeLuaFixture::report_error( const char* message )
+{
+    SWEET_ASSERT( message );
+    if ( show_errors )
+    {
+        fputs( message, stderr );
+        fputs( "\n", stderr );
+        fflush( stderr );
+    }
+}
+
+void ForgeLuaFixture::report_print( const char* message )
+{
+    SWEET_ASSERT( message );
+    if ( show_errors )
+    {
+        fputs( message, stdout );
+        fputs( "\n", stdout );
+        fflush( stdout );
+    }
+}
+
+void ForgeLuaFixture::forge_output( Forge* /*forge*/, const char* message )
+{
+    SWEET_ASSERT( message );
+    if ( show_errors )
+    {
+        fputs( message, stdout );
+        fputs( "\n", stdout );
+        fflush( stdout );
+    }
+}
+
+void ForgeLuaFixture::forge_warning( Forge* /*forge*/, const char* message )
+{
+    SWEET_ASSERT( message );   
+    if ( show_errors )
+    {
+        fputs( "forge_test: ", stderr );
+        fputs( message, stderr );
+        fputs( ".\n", stderr );
+        fflush( stderr );
+    }        
+}
+
+void ForgeLuaFixture::forge_error( Forge* /*forge*/, const char* message )
+{
+    SWEET_ASSERT( message );
+    if ( show_errors )
+    {
+        fputs( "forge_test: ", stderr );
+        fputs( message, stderr );
+        fputs( ".\n", stderr );
+        fflush( stderr );
+    }   
+}
+
+int ForgeLuaFixture::quiet( lua_State* lua_state )
+{
+    const int FIXTURE = lua_upvalueindex( 1 );
+    ForgeLuaFixture* fixture = (ForgeLuaFixture*) lua_touserdata( lua_state, FIXTURE );
+    SWEET_ASSERT( fixture );
+    fixture->show_errors = false;
+    return 0;
+}
+
+int ForgeLuaFixture::verbose( lua_State* lua_state )
+{
+    const int FIXTURE = lua_upvalueindex( 1 );
+    ForgeLuaFixture* fixture = (ForgeLuaFixture*) lua_touserdata( lua_state, FIXTURE );
+    SWEET_ASSERT( fixture );
+    fixture->show_errors = true;
+    return 0;
+}
+
+int ForgeLuaFixture::create( lua_State* lua_state )
+{
+    const int FIXTURE = lua_upvalueindex( 1 );
+    const int FILENAME = 1;
+    const int TIMESTAMP = 2;
+    const int CONTENT = 3;
+    ForgeLuaFixture* fixture = (ForgeLuaFixture*) lua_touserdata( lua_state, FIXTURE );
+    FileChecker* file_checker = (FileChecker*) fixture->file_checker;
+    Forge* forge = fixture->forge;
+    std::time_t timestamp = luaL_optinteger( lua_state, TIMESTAMP, 0 );
+    const char* filename = luaL_tolstring( lua_state, FILENAME, nullptr );
+    const char* content = luaL_optstring( lua_state, CONTENT, "" );
+    file_checker->create( forge->root(filename).string().c_str(), content, timestamp );
+    return 0;
+}
+
+int ForgeLuaFixture::remove( lua_State* lua_state )
+{
+    const int FIXTURE = lua_upvalueindex( 1 );
+    const int FILENAME = 1;
+    ForgeLuaFixture* fixture = (ForgeLuaFixture*) lua_touserdata( lua_state, FIXTURE );
+    FileChecker* file_checker = (FileChecker*) fixture->file_checker;
+    Forge* forge = fixture->forge;
+    const char* filename = luaL_tolstring( lua_state, FILENAME, nullptr );
+    file_checker->remove( forge->root(filename).string().c_str() );
+    return 0;
+}
+
+int ForgeLuaFixture::touch( lua_State* lua_state )
+{
+    const int FIXTURE = lua_upvalueindex( 1 );
+    const int FILENAME = 1;
+    const int TIMESTAMP = 2;
+    ForgeLuaFixture* fixture = (ForgeLuaFixture*) lua_touserdata( lua_state, FIXTURE );
+    FileChecker* file_checker = (FileChecker*) fixture->file_checker;
+    Forge* forge = fixture->forge;
+    std::time_t timestamp = luaL_optinteger( lua_state, TIMESTAMP, 0 );
+    const char* filename = luaL_tolstring( lua_state, FILENAME, nullptr );
+    file_checker->touch( forge->root(filename).string().c_str(), timestamp );
+    return 0;
+}

--- a/src/forge/forge_test/ForgeLuaFixture.hpp
+++ b/src/forge/forge_test/ForgeLuaFixture.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <forge/ForgeEventSink.hpp>
+#include <error/ErrorPolicy.hpp>
+
+struct lua_State;
+
+namespace luaxx
+{
+
+class LuaUnitTest;
+
+}
+
+namespace sweet
+{
+
+namespace forge
+{
+
+class FileChecker;
+class Forge;
+
+class ForgeLuaFixture : public ForgeEventSink, public error::ErrorPolicy
+{
+public:
+    forge::Forge* forge;
+    luaxx::LuaUnitTest* lua_unit_test;
+    FileChecker* file_checker;
+    bool show_errors;
+
+    ForgeLuaFixture();
+    ~ForgeLuaFixture();
+
+private:
+    void report_error( const char* message ) override;
+    void report_print( const char* message ) override;
+    void forge_output( Forge* /*forge*/, const char* message ) override;
+    void forge_warning( Forge* /*forge*/, const char* message ) override;
+    void forge_error( Forge* /*forge*/, const char* message ) override;
+    static int quiet( lua_State* lua_state );
+    static int verbose( lua_State* lua_state );
+    static int create( lua_State* lua_state );
+    static int remove( lua_State* lua_state );
+    static int touch( lua_State* lua_state );
+};
+
+}
+
+}

--- a/src/forge/forge_test/dependencies.cpp
+++ b/src/forge/forge_test/dependencies.cpp
@@ -1,142 +1,18 @@
 //
-// TestTransitiveDependencies.cpp
+// dependencies.cpp
 // Copyright (c) Charles Baker. All rights reserved.
 //
 
-#include "stdafx.hpp"
-#include "FileChecker.hpp"
+#include "ForgeLuaFixture.hpp"
 #include <forge/Forge.hpp>
-#include <forge/ForgeEventSink.hpp>
-#include <error/ErrorPolicy.hpp>
-#include <luaxx/luaxx_unit/LuaUnitTest.hpp>
-#include <assert/assert.hpp>
-#include <lua.hpp>
 #include <UnitTest++/UnitTest++.h>
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/operations.hpp>
-#include <string>
 
-using std::string;
-using namespace sweet;
 using namespace sweet::forge;
-using namespace luaxx;
-using namespace boost::filesystem;
 
 SUITE( dependencies )
 {
-    struct LuaTest : public forge::ForgeEventSink
+    TEST_FIXTURE( ForgeLuaFixture, transitive_dependencies )
     {
-        error::ErrorPolicy* error_policy_;
-        forge::Forge* forge_;
-        luaxx::LuaUnitTest* lua_unit_test_;
-        FileChecker* file_checker_;
-    
-        LuaTest()
-        {
-            path path = boost::filesystem::path( string(TEST_DIRECTORY) );
-            error_policy_ = new error::ErrorPolicy;
-            forge_ = new forge::Forge( path.string(), *error_policy_, this );
-            lua_unit_test_ = new LuaUnitTest;
-            file_checker_ = new FileChecker;
-
-            forge_->reset();
-            forge_->set_root_directory( path.generic_string() );
-            forge_->set_stack_trace_enabled( true );
-            forge_->set_package_path(
-                forge_->root("../lua/?.lua").generic_string() + ";" +
-                forge_->root("../lua/?/init.lua").generic_string()
-            );
-
-            lua_unit_test_->create( forge_->lua_state(), error_policy_ );
-
-            static const luaL_Reg file_functions [] = 
-            {
-                { "create", &LuaTest::create },
-                { "remove", &LuaTest::remove },
-                { "touch", &LuaTest::touch },
-                { nullptr, nullptr }
-            };
-            lua_State* lua_state = forge_->lua_state();
-            lua_pushglobaltable( lua_state );
-            lua_pushlightuserdata( lua_state, file_checker_ );
-            luaL_setfuncs( lua_state, file_functions, 1 );    
-            lua_pop( lua_state, 1 );
-        }
-
-        ~LuaTest()
-        {
-            delete file_checker_;
-            delete lua_unit_test_;
-            delete forge_;
-            delete error_policy_;
-        }
-
-        void forge_output( Forge* /*forge*/, const char* message )
-        {
-            SWEET_ASSERT( message );
-            fputs( message, stdout );
-            fputs( "\n", stdout );
-            fflush( stdout );
-        }
-
-        void forge_warning( Forge* /*forge*/, const char* message )
-        {
-            SWEET_ASSERT( message );            
-            fputs( "forge_test: ", stderr );
-            fputs( message, stderr );
-            fputs( ".\n", stderr );
-            fflush( stderr );
-        }
-
-        void forge_error( Forge* /*forge*/, const char* message )
-        {
-            SWEET_ASSERT( message );            
-            fputs( "forge_test: ", stderr );
-            fputs( message, stderr );
-            fputs( ".\n", stderr );
-            fflush( stderr );
-        }
-
-        static int create( lua_State* lua_state )
-        {
-            const int LUA_TEST = lua_upvalueindex( 1 );
-            const int FILENAME = 1;
-            const int TIMESTAMP = 2;
-            const int CONTENT = 3;
-            FileChecker* file_checker = (FileChecker*) lua_touserdata( lua_state, LUA_TEST );
-            std::time_t timestamp = luaL_optinteger( lua_state, TIMESTAMP, 0 );
-            const char* filename = luaL_tolstring( lua_state, FILENAME, nullptr );
-            const char* content = luaL_optstring( lua_state, CONTENT, "" );
-            file_checker->create( filename, content, timestamp );
-            return 0;
-        }
-
-        static int remove( lua_State* lua_state )
-        {
-            const int LUA_TEST = lua_upvalueindex( 1 );
-            const int FILENAME = 1;
-            FileChecker* file_checker = (FileChecker*) lua_touserdata( lua_state, LUA_TEST );
-            const char* filename = luaL_tolstring( lua_state, FILENAME, nullptr );
-            file_checker->remove( filename );
-            return 0;
-        }
-
-        static int touch( lua_State* lua_state )
-        {
-            const int LUA_TEST = lua_upvalueindex( 1 );
-            const int FILENAME = 1;
-            const int TIMESTAMP = 2;
-            FileChecker* file_checker = (FileChecker*) lua_touserdata( lua_state, LUA_TEST );
-            std::time_t timestamp = luaL_optinteger( lua_state, TIMESTAMP, 0 );
-            const char* filename = luaL_tolstring( lua_state, FILENAME, nullptr );
-            file_checker->touch( filename, timestamp );
-            return 0;
-        }
-
-    };
-
-    TEST_FIXTURE( LuaTest, transitive_dependencies )
-    {
-        forge_->file( "transitive_dependencies.lua" );
+        forge->file( "transitive_dependencies.lua" );
     }
 }

--- a/src/forge/forge_test/forge_test.forge
+++ b/src/forge/forge_test/forge_test.forge
@@ -35,6 +35,7 @@ for _, cc in toolsets('cc.*') do
                 'main.cpp',
                 'ErrorChecker.cpp',
                 'FileChecker.cpp',
+                'ForgeLuaFixture.cpp',
                 'TestDirectoryApi.cpp',
                 'TestGraph.cpp',
                 'TestPostorder.cpp'

--- a/src/forge/forge_test/forge_test.forge
+++ b/src/forge/forge_test/forge_test.forge
@@ -17,11 +17,11 @@ for _, cc in toolsets('cc.*') do
     };
     cc:all {
         cc:Executable '${bin}/forge_test' {
+            '${lib}/assert_${architecture}';
             '${lib}/cmdline_test_${architecture}';
+            '${lib}/error_${architecture}';
             '${lib}/forge_${architecture}';
             '${lib}/luaxx_unit_${architecture}';
-            '${lib}/assert_${architecture}';
-            '${lib}/error_${architecture}';
             '${lib}/UnitTest++_${platform}_${architecture}';
 
             libraries = libraries;
@@ -33,6 +33,7 @@ for _, cc in toolsets('cc.*') do
                 };
                 'dependencies.cpp',
                 'main.cpp',
+                'preorder.cpp',
                 'ErrorChecker.cpp',
                 'FileChecker.cpp',
                 'ForgeLuaFixture.cpp',

--- a/src/forge/forge_test/preorder.cpp
+++ b/src/forge/forge_test/preorder.cpp
@@ -1,0 +1,18 @@
+//
+// preorder.cpp
+// Copyright (c) Charles Baker. All rights reserved.
+//
+
+#include "ForgeLuaFixture.hpp"
+#include <forge/Forge.hpp>
+#include <UnitTest++/UnitTest++.h>
+
+using namespace sweet::forge;
+
+SUITE( preorder )
+{
+    TEST_FIXTURE( ForgeLuaFixture, preorder )
+    {
+        forge->file( "preorder.lua" );
+    }
+}

--- a/src/forge/forge_test/preorder.lua
+++ b/src/forge/forge_test/preorder.lua
@@ -1,0 +1,88 @@
+
+local forge = require( 'forge' ):load();
+local toolset = forge.Toolset();
+
+local one = toolset:Target 'one' {
+    'two';
+    'three';
+};
+
+local two = toolset:Target 'two' {
+    'four';
+    'three';
+};
+
+local three = toolset:Target 'three' {
+};
+
+local four = toolset:Target 'four' {
+};
+
+TestSuite {
+    preorder_traversal_order = function()
+        local expected_order = { 'one', 'two', 'three', 'four' };
+        local index = 1;
+        local failures = preorder( one, function( target )
+            if index == 1 then
+                CHECK( target == one );
+            elseif index == 2 then
+                CHECK( target == two );
+            elseif index == 3 then
+                CHECK( target == three );
+            elseif index == 4 then
+                CHECK( target == four );
+            end
+            index = index + 1;
+        end );
+        CHECK_EQUAL( 0, failures );
+    end;
+
+    assert_in_preorder_traversal = function()
+        local failures = preorder( one, function( target ) 
+            assert( false );
+        end );
+        CHECK_EQUAL( 1, failures );
+    end;
+
+    error_in_preorder_traversal = function()
+        local failures = preorder( one, function( target ) 
+            error( 'testing error in preorder traversal' );
+        end );
+        CHECK_EQUAL( 1, failures );
+    end;
+
+    yield_from_execute_in_preorder_traversal = function()
+        local echo_dev_null = 'echo >/dev/null';
+        if operating_system() == 'windows' then
+            echo_dev_null = 'echo >nul';
+        end
+        preorder( one, function( target ) 
+            shell( {echo_dev_null; target:id()} );
+        end );
+    end;
+
+    non_existing_executable_in_preorder_traversal = function()
+        local failures = preorder( one, function( target ) 
+            system( '/this/executable/does/not/exist', '' );
+        end );
+        CHECK_EQUAL( 1, failures );
+    end;
+
+    yield_from_buildfile_in_preorder_traversal = function()
+        create( 'yield_from_buildfile_in_preorder_traversal.build', nil, [[
+            buildfile( 'yield_from_recursive_buildfile_in_preorder_traversal.build' );
+        ]] );
+        create( 'yield_from_recursive_buildfile_in_preorder_traversal.build' );
+        local failures = preorder( one, function( target )
+            buildfile( 'yield_from_buildfile_in_preorder_traversal.build' );
+        end );
+        CHECK_EQUAL( 0, failures );
+    end;
+
+    non_existing_buildfile_in_preorder_traversal = function()
+        local failures = preorder( one, function( target ) 
+            assert( false );
+        end );
+        CHECK_EQUAL( 1, failures );
+    end;
+};

--- a/src/forge/forge_test/transitive_dependencies.lua
+++ b/src/forge/forge_test/transitive_dependencies.lua
@@ -1,5 +1,5 @@
 
-local forge = require 'forge';
+local forge = require( 'forge' ):load();
 local toolset = forge.Toolset();
 toolset:install( 'forge.cc' );
 


### PR DESCRIPTION
Allows yielding `execute()` and `buildfile()` calls from within coroutines spawned as part of a `preorder()` call.