### PR TITLE
Make root directory the highest directory containing forge.lua

### DIFF
--- a/docs/getting-started/running-forge.md
+++ b/docs/getting-started/running-forge.md
@@ -29,9 +29,9 @@ Commands:
   namespace          Print target hierarchy.
 ~~~
 
-Run `forge` from a directory within the project.  Forge searches up from that directory looking for files named *forge.lua*.  The file found in the highest directory is the root build script executed to define the build.  The directory containing the root build script is the root directory of the project.
+Run `forge` from a directory within the project.  When invoked `forge` searches up from the current working directory looking for files named `forge.lua`.  The file in the highest level directory is the root build script, executed to configure the build.  The directory containing `forge.lua` becomes the root directory of the project.
 
-The directory that `forge` is run from is the initial working directory.  By default the target named *all* in this initial directory is built.  Building from the root directory of the project typically builds all useful outputs for a project.  Building from sub-directories of the project typically builds targets defined in that directory only.
+The directory that `forge` is run from is the initial working directory.  By default the target named *all* in this directory is built.  Building from the root directory of the project typically builds all useful outputs for a project.  Building from sub-directories of the project typically builds targets defined in that directory only.
 
 ### Commands
 

--- a/src/forge/path_functions.cpp
+++ b/src/forge/path_functions.cpp
@@ -116,8 +116,8 @@ boost::filesystem::path make_drive_uppercase( std::string path )
 // Search up from *directory* to find *filename* in the root directory.
 //
 // Searches up the directory hierarchy from *directory* to the root directory 
-// to find the first directory containing a file named *filename*.  This
-// directory is returned as the root directory for the build.
+// to find the highest directory containing a file named *filename*.  This 
+// directory is returned as the root directory.
 //
 // @param directory
 //  The directory to start the search from.
@@ -128,16 +128,21 @@ boost::filesystem::path make_drive_uppercase( std::string path )
 boost::filesystem::path search_up_for_root_directory( const std::string& directory, const std::string& filename )
 {
     using boost::filesystem::exists;
+    boost::filesystem::path root_directory;
     boost::filesystem::path current_directory( directory );
     while ( !current_directory.empty() && current_directory.has_root_directory() )
     {
         if ( exists((current_directory / filename).string()) )
         {
-            return make_drive_uppercase( current_directory.generic_string() );
+            root_directory = current_directory;
         }
         current_directory = current_directory.branch_path();
     }
-    return boost::filesystem::path();
+    if ( !exists((root_directory / filename).string()) )
+    {
+        return boost::filesystem::path();
+    }
+    return make_drive_uppercase( root_directory.generic_string() );
 }
 
 }


### PR DESCRIPTION
Treating the first directory containing `forge.lua` as the root directory is confusing when building projects with submodules that also contain `forge.lua`.

The desired behavior in this case is to use the settings setup in `forge.lua` for the containing project, i.e. the `forge.lua` in the highest level directory *not* the first directory found when searching up from the current working directory that contains `forge.lua`.
