### PR TITLE
Ignore temporary files in automatic dependencies

### DIFF
--- a/src/forge/forge_hooks/forge_hooks_linux.cpp
+++ b/src/forge/forge_hooks/forge_hooks_linux.cpp
@@ -66,7 +66,7 @@ int open( const char* filename, int oflag, ... )
     }
 
     int fd = -1;
-    if ( oflag & (O_CREAT | O_TMPFILE) )
+    if ( oflag & O_CREAT )
     {
         va_list args;
         va_start( args, oflag );
@@ -92,7 +92,7 @@ int open64( const char* filename, int oflag, ... )
     }
 
     int fd = -1;
-    if ( oflag & (O_CREAT | O_TMPFILE) )
+    if ( oflag & O_CREAT )
     {
         va_list args;
         va_start( args, oflag );
@@ -118,7 +118,7 @@ int openat( int dirfd, const char* filename, int oflag, ... )
     }
 
     int fd = -1;
-    if ( oflag & (O_CREAT | O_TMPFILE) )
+    if ( oflag & O_CREAT )
     {
         va_list args;
         va_start( args, oflag );

--- a/src/forge/forge_hooks/forge_hooks_windows.cpp
+++ b/src/forge/forge_hooks/forge_hooks_windows.cpp
@@ -119,7 +119,7 @@ static HANDLE WINAPI create_file_a_hook( LPCSTR filename, DWORD desired_access, 
         flags,
         template_file
     );
-    if ( handle != INVALID_HANDLE_VALUE )
+    if ( handle != INVALID_HANDLE_VALUE && (flags & FILE_ATTRIBUTE_TEMPORARY) == 0 )
     {
         log_file_access( filename, desired_access & GENERIC_WRITE );
     }
@@ -137,7 +137,7 @@ static HANDLE WINAPI create_file_w_hook( LPCWSTR wide_filename, DWORD desired_ac
         flags,
         template_file
     );
-    if ( handle != INVALID_HANDLE_VALUE )
+    if ( handle != INVALID_HANDLE_VALUE && (flags & FILE_ATTRIBUTE_TEMPORARY) == 0 )
     {
         char filename [MAX_PATH + 1];
         int count = WideCharToMultiByte( CP_UTF8, 0, wide_filename, (int) wcslen(wide_filename), filename, (int) sizeof(filename), NULL, NULL );
@@ -161,7 +161,7 @@ static HANDLE WINAPI create_file_transacted_a_hook( LPCSTR filename, DWORD desir
         mini_version,
         extended_parameter
     );
-    if ( handle != INVALID_HANDLE_VALUE )
+    if ( handle != INVALID_HANDLE_VALUE && (flags & FILE_ATTRIBUTE_TEMPORARY) == 0 )
     {
         log_file_access( filename, desired_access & GENERIC_WRITE );
     }
@@ -182,7 +182,7 @@ static HANDLE WINAPI create_file_transacted_w_hook( LPCWSTR wide_filename, DWORD
         mini_version,
         extended_parameter
     );
-    if ( handle != INVALID_HANDLE_VALUE )
+    if ( handle != INVALID_HANDLE_VALUE && (flags & FILE_ATTRIBUTE_TEMPORARY) == 0 )
     {
         char filename [MAX_PATH + 1];
         int count = WideCharToMultiByte( CP_UTF8, 0, wide_filename, (int) wcslen(wide_filename), filename, (int) sizeof(filename), NULL, NULL );

--- a/src/forge/forge_hooks/forge_hooks_windows.cpp
+++ b/src/forge/forge_hooks/forge_hooks_windows.cpp
@@ -348,9 +348,6 @@ static BOOL WINAPI create_process_w_hook( LPCWSTR application_name, LPWSTR comma
         startup_info,
         process_information 
     );
-    char filename [MAX_PATH + 1];
-    int count = WideCharToMultiByte( CP_UTF8, 0, application_name, (int) wcslen(application_name), filename, (int) sizeof(filename), NULL, NULL );
-    filename[count] = 0;
     return success;
 }
 
@@ -387,9 +384,6 @@ static BOOL WINAPI create_process_as_user_w_hook( HANDLE token, LPCWSTR applicat
         startup_info,
         process_information
     );
-    char filename [MAX_PATH + 1];
-    int count = WideCharToMultiByte( CP_UTF8, 0, application_name, (int) wcslen(application_name), filename, (int) sizeof(filename), NULL, NULL );
-    filename[count] = 0;
     return success;
 }
 
@@ -408,9 +402,6 @@ static BOOL WINAPI create_process_with_logon_w_hook( LPCWSTR username, LPCWSTR d
         startup_info,
         process_information        
     );
-    char filename [MAX_PATH + 1];
-    int count = WideCharToMultiByte( CP_UTF8, 0, application_name, (int) wcslen(application_name), filename, (int) sizeof(filename), NULL, NULL );
-    filename[count] = 0;
     return success;
 }
 
@@ -427,9 +418,6 @@ static BOOL WINAPI create_process_with_token_w_hook( HANDLE token, DWORD logon_f
         startup_info, 
         process_information    
     );
-    char filename [MAX_PATH + 1];
-    int count = WideCharToMultiByte( CP_UTF8, 0, application_name, (int) wcslen(application_name), filename, (int) sizeof(filename), NULL, NULL );
-    filename[count] = 0;
     return success;
 }
 

--- a/src/forge/forge_hooks/forge_hooks_windows.cpp
+++ b/src/forge/forge_hooks/forge_hooks_windows.cpp
@@ -53,86 +53,6 @@ typedef HANDLE (WINAPI *CreateFileTransactedWFunction)(
     PVOID extended_parameter
 );
 
-typedef BOOL (WINAPI *CreateProcessAFunction)( 
-    LPCSTR application_name, 
-    LPSTR command_line,
-    LPSECURITY_ATTRIBUTES process_attributes,
-    LPSECURITY_ATTRIBUTES thread_attributes,
-    BOOL inherit_handles,
-    DWORD creation_flags,
-    LPVOID environment,
-    LPCSTR current_directory,
-    LPSTARTUPINFO startup_info,
-    LPPROCESS_INFORMATION process_information
-);
-
-typedef BOOL (WINAPI *CreateProcessWFunction)( 
-    LPCWSTR application_name, 
-    LPWSTR command_line,
-    LPSECURITY_ATTRIBUTES process_attributes,
-    LPSECURITY_ATTRIBUTES thread_attributes,
-    BOOL inherit_handles,
-    DWORD creation_flags,
-    LPVOID environment,
-    LPCWSTR current_directory,
-    LPSTARTUPINFO startup_info,
-    LPPROCESS_INFORMATION process_information
-);
-
-typedef BOOL (WINAPI *CreateProcessAsUserAFunction)(
-    HANDLE token,
-    LPCSTR application_name,
-    LPSTR command_line,
-    LPSECURITY_ATTRIBUTES process_attributes,
-    LPSECURITY_ATTRIBUTES thread_attributes,
-    BOOL inherit_handles,
-    DWORD creation_flags,
-    LPVOID environment,
-    LPCSTR current_directory,
-    LPSTARTUPINFOA startup_info,
-    LPPROCESS_INFORMATION process_information
-);
-
-typedef BOOL (WINAPI *CreateProcessAsUserWFunction)(
-    HANDLE token,
-    LPCWSTR application_name,
-    LPWSTR command_line,
-    LPSECURITY_ATTRIBUTES process_attributes,
-    LPSECURITY_ATTRIBUTES thread_attributes,
-    BOOL inherit_handles,
-    DWORD creation_flags,
-    LPVOID environment,
-    LPCWSTR current_directory,
-    LPSTARTUPINFOW startup_info,
-    LPPROCESS_INFORMATION process_information
-);
-
-typedef BOOL (WINAPI *CreateProcessWithLogonWFunction)(
-    LPCWSTR username,
-    LPCWSTR domain,
-    LPCWSTR password,
-    DWORD logon_flags,
-    LPCWSTR application_name,
-    LPWSTR command_line,
-    DWORD creation_flags,
-    LPVOID environment,
-    LPCWSTR current_directory,
-    LPSTARTUPINFOW startup_info,
-    LPPROCESS_INFORMATION process_information
-);
-
-typedef BOOL (WINAPI *CreateProcessWithTokenWFunction)(
-    HANDLE token,
-    DWORD logon_flags,
-    LPCWSTR application_name,
-    LPWSTR command_line,
-    DWORD creation_flags,
-    LPVOID environment,
-    LPCWSTR current_directory,
-    LPSTARTUPINFOW startup_info,
-    LPPROCESS_INFORMATION process_information
-);
-
 typedef NTSTATUS (WINAPI *NtOpenFileFunction)(
     PHANDLE file_handle,
     ACCESS_MASK desired_access,
@@ -156,58 +76,13 @@ typedef NTSTATUS (WINAPI *NtCreateFileFunction)(
     ULONG ea_length
 );
 
-typedef NTSTATUS (WINAPI *NtCreateUserProcessFunction)(
-    PHANDLE process_handle,
-    PHANDLE thread_handle,
-    ACCESS_MASK process_desired_access,
-    ACCESS_MASK thread_desired_access,
-    POBJECT_ATTRIBUTES process_object_attributes,
-    POBJECT_ATTRIBUTES thread_object_attributes,
-    ULONG process_flags,
-    ULONG thread_flags,
-    PRTL_USER_PROCESS_PARAMETERS process_parameters,
-    ULONG_PTR create_info,
-    ULONG_PTR attribute_list
-);
-
-typedef HMODULE (WINAPI *LoadLibraryAFunction)(
-    LPCSTR filename
-);
-
-typedef HMODULE (WINAPI *LoadLibraryWFunction)(
-    LPCWSTR filename
-);
-
-typedef HMODULE (WINAPI *LoadLibraryExAFunction)(
-    LPCSTR filename,
-    HANDLE file,
-    DWORD flags
-);
-
-typedef HMODULE (WINAPI *LoadLibraryExWFunction)(
-    LPCWSTR filename,
-    HANDLE file,
-    DWORD flags
-);
-
 static HANDLE build_hooks_dependencies_pipe = INVALID_HANDLE_VALUE;
 static CreateFileAFunction original_create_file_a = NULL;
 static CreateFileWFunction original_create_file_w = NULL;
 static CreateFileTransactedAFunction original_create_file_transacted_a = NULL;
 static CreateFileTransactedWFunction original_create_file_transacted_w = NULL;
-static CreateProcessAFunction original_create_process_a = NULL;
-static CreateProcessWFunction original_create_process_w = NULL;
-static CreateProcessAsUserAFunction original_create_process_as_user_a = NULL;
-static CreateProcessAsUserWFunction original_create_process_as_user_w = NULL;
-static CreateProcessWithLogonWFunction original_create_process_with_logon_w = NULL;
-static CreateProcessWithTokenWFunction original_create_process_with_token_w = NULL;
 static NtOpenFileFunction original_nt_open_file = NULL;
 static NtCreateFileFunction original_nt_create_file = NULL;
-static NtCreateUserProcessFunction original_nt_create_user_process = NULL;
-static LoadLibraryAFunction original_load_library_a = NULL;
-static LoadLibraryWFunction original_load_library_w = NULL;
-static LoadLibraryExAFunction original_load_library_ex_a = NULL;
-static LoadLibraryExWFunction original_load_library_ex_w = NULL;
 
 // Skip the "\\?\" or "\??\" prefixes used to disable string parsing in
 // Windows APIs.  Forge scripts that handle these are expecting paths
@@ -317,123 +192,6 @@ static HANDLE WINAPI create_file_transacted_w_hook( LPCWSTR wide_filename, DWORD
     return handle;
 }
 
-static BOOL WINAPI create_process_a_hook( LPCSTR application_name, LPSTR command_line, LPSECURITY_ATTRIBUTES process_attributes, LPSECURITY_ATTRIBUTES thread_attributes, BOOL inherit_handles, DWORD creation_flags, LPVOID environment, LPCSTR current_directory, LPSTARTUPINFO startup_info, LPPROCESS_INFORMATION process_information )
-{
-    BOOL success = (*original_create_process_a)( 
-        application_name, 
-        command_line, 
-        process_attributes, 
-        thread_attributes, 
-        inherit_handles, 
-        creation_flags,
-        environment,
-        current_directory,
-        startup_info,
-        process_information 
-    );
-    return success;
-}
-
-static BOOL WINAPI create_process_w_hook( LPCWSTR application_name, LPWSTR command_line, LPSECURITY_ATTRIBUTES process_attributes, LPSECURITY_ATTRIBUTES thread_attributes, BOOL inherit_handles, DWORD creation_flags, LPVOID environment, LPCWSTR current_directory, LPSTARTUPINFO startup_info, LPPROCESS_INFORMATION process_information )
-{
-    BOOL success = (*original_create_process_w)( 
-        application_name, 
-        command_line, 
-        process_attributes, 
-        thread_attributes, 
-        inherit_handles, 
-        creation_flags,
-        environment,
-        current_directory,
-        startup_info,
-        process_information 
-    );
-    return success;
-}
-
-static BOOL WINAPI create_process_as_user_a_hook( HANDLE token, LPCSTR application_name, LPSTR command_line, LPSECURITY_ATTRIBUTES process_attributes, LPSECURITY_ATTRIBUTES thread_attributes, BOOL inherit_handles, DWORD creation_flags, LPVOID environment, LPCSTR current_directory, LPSTARTUPINFOA startup_info, LPPROCESS_INFORMATION process_information )
-{
-    BOOL success = (*original_create_process_as_user_a)(
-        token,
-        application_name,
-        command_line,
-        process_attributes,
-        thread_attributes,
-        inherit_handles,
-        creation_flags,
-        environment,
-        current_directory,
-        startup_info,
-        process_information
-    );
-    return success;
-}
-
-static BOOL WINAPI create_process_as_user_w_hook( HANDLE token, LPCWSTR application_name, LPWSTR command_line, LPSECURITY_ATTRIBUTES process_attributes, LPSECURITY_ATTRIBUTES thread_attributes, BOOL inherit_handles, DWORD creation_flags, LPVOID environment, LPCWSTR current_directory, LPSTARTUPINFOW startup_info, LPPROCESS_INFORMATION process_information )
-{
-    BOOL success = (*original_create_process_as_user_w)(
-        token,
-        application_name,
-        command_line,
-        process_attributes,
-        thread_attributes,
-        inherit_handles,
-        creation_flags,
-        environment,
-        current_directory,
-        startup_info,
-        process_information
-    );
-    return success;
-}
-
-static BOOL WINAPI create_process_with_logon_w_hook( LPCWSTR username, LPCWSTR domain, LPCWSTR password, DWORD logon_flags, LPCWSTR application_name, LPWSTR command_line, DWORD creation_flags, LPVOID environment, LPCWSTR current_directory, LPSTARTUPINFOW startup_info, LPPROCESS_INFORMATION process_information )
-{
-    BOOL success = (*original_create_process_with_logon_w)(
-        username,
-        domain,
-        password,
-        logon_flags,
-        application_name,
-        command_line,
-        creation_flags,
-        environment,
-        current_directory,
-        startup_info,
-        process_information        
-    );
-    return success;
-}
-
-static BOOL WINAPI create_process_with_token_w_hook( HANDLE token, DWORD logon_flags, LPCWSTR application_name, LPWSTR command_line, DWORD creation_flags, LPVOID environment, LPCWSTR current_directory, LPSTARTUPINFOW startup_info, LPPROCESS_INFORMATION process_information )
-{
-    BOOL success = (*original_create_process_with_token_w)(
-        token, 
-        logon_flags, 
-        application_name, 
-        command_line, 
-        creation_flags, 
-        environment, 
-        current_directory, 
-        startup_info, 
-        process_information    
-    );
-    return success;
-}
-
-static NTSTATUS WINAPI nt_open_file_hook( PHANDLE file_handle, ACCESS_MASK desired_access, POBJECT_ATTRIBUTES object_attributes, PIO_STATUS_BLOCK io_status_block, ULONG share_access, ULONG open_options )
-{
-    NTSTATUS status = (*original_nt_open_file)(        
-        file_handle,
-        desired_access,
-        object_attributes,
-        io_status_block,
-        share_access,
-        open_options
-    );
-    return status;
-}
-
 static NTSTATUS WINAPI nt_create_file_hook( PHANDLE file_handle, ACCESS_MASK desired_access, POBJECT_ATTRIBUTES object_attributes, PIO_STATUS_BLOCK io_status_block, PLARGE_INTEGER allocation_size, ULONG file_attributes, ULONG share_access, ULONG creation_disposition, ULONG create_options, PVOID ea_buffer, ULONG ea_length )
 {
     NTSTATUS status = (*original_nt_create_file)(
@@ -460,70 +218,6 @@ static NTSTATUS WINAPI nt_create_file_hook( PHANDLE file_handle, ACCESS_MASK des
     return status;
 }
 
-static NTSTATUS WINAPI nt_create_user_process_hook( PHANDLE process_handle, PHANDLE thread_handle, ACCESS_MASK process_desired_access, ACCESS_MASK thread_desired_access, POBJECT_ATTRIBUTES process_object_attributes, POBJECT_ATTRIBUTES thread_object_attributes, ULONG process_flags, ULONG thread_flags, PRTL_USER_PROCESS_PARAMETERS process_parameters, ULONG_PTR create_info, ULONG_PTR attribute_list )
-{
-    NTSTATUS status = (*original_nt_create_user_process)(
-        process_handle,
-        thread_handle,
-        process_desired_access,
-        thread_desired_access,
-        process_object_attributes,
-        thread_object_attributes,
-        process_flags,
-        thread_flags,
-        process_parameters,
-        create_info,
-        attribute_list
-    );
-    return status;
-}
-
-static HMODULE WINAPI load_library_a_hook( LPCSTR filename )
-{
-    HMODULE module = (*original_load_library_a)( 
-        filename
-    );
-    // patch_iat( module );
-    return module;
-}
-
-static HMODULE WINAPI load_library_w_hook( LPCWSTR wide_filename )
-{
-    HMODULE module = (*original_load_library_w)( 
-        wide_filename
-    );
-    char filename [MAX_PATH + 1];
-    int count = WideCharToMultiByte( CP_UTF8, 0, wide_filename, (int) wcslen(wide_filename), filename, (int) sizeof(filename), NULL, NULL );
-    filename[count] = 0;
-    // patch_iat( module );
-    return module;
-}
-
-static HMODULE WINAPI load_library_ex_a_hook( LPCSTR filename, HANDLE file, DWORD flags )
-{
-    HMODULE module = (*original_load_library_ex_a)( 
-        filename,
-        file,
-        flags
-    );
-    // patch_iat( module );
-    return module;
-}
-
-static HMODULE WINAPI load_library_ex_w_hook( LPCWSTR wide_filename, HANDLE file, DWORD flags )
-{
-    HMODULE module = (*original_load_library_ex_w)( 
-        wide_filename,
-        file,
-        flags
-    );
-    char filename [MAX_PATH + 1];
-    int count = WideCharToMultiByte( CP_UTF8, 0, wide_filename, (int) wcslen(wide_filename), filename, (int) sizeof(filename), NULL, NULL );
-    filename[count] = 0;
-    // patch_iat( module );
-    return module;
-}
-
 static void patch_iat( HMODULE module )
 {
     HMODULE modules [256];
@@ -543,16 +237,6 @@ static void patch_iat( HMODULE module )
                 kernel32.patch_function( "CreateFileW", (void*) &create_file_w_hook, (void**) &original_create_file_w );
                 kernel32.patch_function( "CreateFileTransactedA", (void*) &create_file_transacted_a_hook, (void**) &original_create_file_transacted_a );
                 kernel32.patch_function( "CreateFileTransactedW", (void*) &create_file_transacted_w_hook, (void**) &original_create_file_transacted_w );
-                kernel32.patch_function( "CreateProcessA", (void*) &create_process_a_hook, (void**) &original_create_process_a );
-                kernel32.patch_function( "CreateProcessW", (void*) &create_process_w_hook, (void**) &original_create_process_w );
-                kernel32.patch_function( "CreateProcessAsUserA", (void*) &create_process_as_user_a_hook, (void**) &original_create_process_as_user_a );
-                kernel32.patch_function( "CreateProcessAsUserW", (void*) &create_process_as_user_w_hook, (void**) &original_create_process_as_user_w );
-                kernel32.patch_function( "CreateProcessWithLogonW", (void*) &create_process_with_logon_w_hook, (void**) &original_create_process_with_logon_w );
-                kernel32.patch_function( "CreateProcessWithTokenW", (void*) &create_process_with_token_w_hook, (void**) &original_create_process_with_token_w );
-                kernel32.patch_function( "LoadLibraryA", (void*) &load_library_a_hook, (void**) &original_load_library_a );
-                kernel32.patch_function( "LoadLibraryW", (void*) &load_library_w_hook, (void**) &original_load_library_w );
-                kernel32.patch_function( "LoadLibraryExA", (void*) &load_library_ex_a_hook, (void**) &original_load_library_ex_a );
-                kernel32.patch_function( "LoadLibraryExW", (void*) &load_library_ex_w_hook, (void**) &original_load_library_ex_w );
             }
 
             ImportDescriptor ntdll( base_address, "ntdll.dll" );

--- a/src/forge/lua/forge/Toolset.lua
+++ b/src/forge/lua/forge/Toolset.lua
@@ -108,9 +108,9 @@ function Toolset:dependencies_filter( target )
     target:clear_implicit_dependencies();
     return function( line )
         if line:match('^==') then 
-            local READ_PATTERN = "^== read '([^']*)'";
-            local path = line:match( READ_PATTERN );
-            if path then
+            local ACCESS_PATTERN = "^== (%a+) '([^']*)'";
+            local access, path = line:match( ACCESS_PATTERN );
+            if access and path and access == 'read' then
                 local relative_path = relative( absolute(path), root() );
                 local within_source_tree = is_relative(relative_path) and relative_path:find( '..', 1, true ) == nil;
                 if within_source_tree then 
@@ -132,13 +132,13 @@ function Toolset:filenames_filter( target )
     local output_directory = target:ordering_dependency():filename();
     return function( line )
         if line:match('^==') then
-            local READ_WRITE_PATTERN = "^== (%a+) '([^']*)'";
-            local read_write, path = line:match( READ_WRITE_PATTERN );
-            if read_write and path then
+            local ACCESS_PATTERN = "^== (%a+) '([^']*)'";
+            local access, path = line:match( ACCESS_PATTERN );
+            if access and path then
                 local relative_path = relative( absolute(path), output_directory );
                 local within_source_tree = is_relative(relative_path) and relative_path:find( '..', 1, true ) == nil;
                 if within_source_tree then 
-                    if read_write == 'write' then
+                    if access == 'write' then
                         target:add_filename( path );
                     else
                         local source_file = self:SourceFile( path );


### PR DESCRIPTION
The ConTexT typesetter uses `O_TMPFILE` and `FILE_ATTRIBUTE_TEMPORARY` to create temporary files that are deleted when the last handle to them is closed.  These files are added as dependencies of the output file, e.g. the PDF in the case of ConTeXt.  That causes Forge to continually rebuild that output file because it has dependencies that don't exist.

Fixed by quietly ignoring temporary files detected in the Linux and Windows hooks libraries.