### PR TITLE
Use the constant PATH_MAX to size the array passed to _NSGetExecutablePath()

### DIFF
--- a/src/forge/System.cpp
+++ b/src/forge/System.cpp
@@ -170,9 +170,8 @@ std::string System::executable() const
     }
     return std::string();
 #elif defined(BUILD_OS_MACOS)
-    uint32_t size = 0;
-    _NSGetExecutablePath( NULL, &size );
-    char executable_path [size];
+    uint32_t size = PATH_MAX;
+    char executable_path [PATH_MAX];
     _NSGetExecutablePath( executable_path, &size );
     char linked_path [PATH_MAX];
     int linked_size = readlink( executable_path, linked_path, sizeof(linked_path) - 1 );

--- a/src/forge/lua/forge/cc/clang.lua
+++ b/src/forge/lua/forge/cc/clang.lua
@@ -265,7 +265,6 @@ function clang.append_compile_flags(toolset, target, flags, language)
 
     if toolset.optimization then
         table.insert(flags, '-O3');
-        table.insert(flags, '-Ofast');
     end
 
     if toolset.preprocess then

--- a/src/forge/lua/forge/cc/gcc.lua
+++ b/src/forge/lua/forge/cc/gcc.lua
@@ -217,7 +217,6 @@ function gcc.append_compile_flags(toolset, target, flags, language)
 
     if toolset.optimization then
         table.insert(flags, '-O3');
-        table.insert(flags, '-Ofast');
     end
 
     if toolset.preprocess then


### PR DESCRIPTION
Latest macOS build is complaining that variable length arrays are a Clang extension that needs to be explicitly enabled.  I'd rather the code be simpler so fixed by using PATH_MAX instead of dynamically sizing the array.